### PR TITLE
Pin isort version to 4.x due to big changes in 5.x

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,3 @@
 [build-system]
-requires = ["setuptools>=42", "wheel", "setuptools_scm[toml]>=3.4", "black", "isort", "xmlschema", "pydantic"]
+requires = ["setuptools>=42", "wheel", "setuptools_scm[toml]>=3.4", "black", "isort<5.0", "xmlschema", "pydantic"]
 build-backend = "setuptools.build_meta"

--- a/setup.cfg
+++ b/setup.cfg
@@ -32,7 +32,7 @@ install_requires =
     xmlschema>=1.0.16
 
 [options.extras_require]
-autogen = isort; black
+autogen = isort<5.0; black
 
 
 [options.packages.find]


### PR DESCRIPTION
isort 5.0 both makes backwards-incompatible changes to the Python API and stops sorting and de-duplicating imports across blocks. I created an `isort-5` branch to just update to the new API, but then I realized the codegen output didn't look as nice. Maybe a minor issue, but you can decide which approach you prefer!