### PR TITLE
add --nogen option to run tests on pregenerated code

### DIFF
--- a/testing/conftest.py
+++ b/testing/conftest.py
@@ -1,0 +1,7 @@
+def pytest_addoption(parser):
+    parser.addoption(
+        "--nogen",
+        default=False,
+        action="store_true",
+        help="run tests on pregenerated model",
+    )

--- a/testing/test_autogen.py
+++ b/testing/test_autogen.py
@@ -53,7 +53,6 @@ SHOULD_RAISE = {"bad"}
 
 
 def mark_xfail(fname):
-    return fname
     return pytest.param(
         fname,
         marks=pytest.mark.xfail(

--- a/testing/test_autogen.py
+++ b/testing/test_autogen.py
@@ -2,20 +2,26 @@ import importlib
 import os
 import sys
 from glob import glob
+from pathlib import Path
 
 import pytest
 from xmlschema.validators.exceptions import XMLSchemaValidationError
 
-from ome_autogen import convert_schema
-from ome_types import from_xml
-from pathlib import Path
-
-
 TESTING_DIR = Path(__file__).parent
+SRC_MODEL = TESTING_DIR.parent / "src" / "ome_types" / "model"
 
 
 @pytest.fixture(scope="session")
-def model(tmp_path_factory):
+def model(tmp_path_factory, request):
+    if request.config.getoption("--nogen"):
+        if not SRC_MODEL.exists():
+            raise RuntimeError(
+                f"Please generate local {SRC_MODEL} before using --nogen"
+            )
+        sys.path.insert(0, str(SRC_MODEL.parent))
+        return importlib.import_module(SRC_MODEL.name)
+    from ome_autogen import convert_schema
+
     target_dir = tmp_path_factory.mktemp("test_model")
     xsd = TESTING_DIR / "ome-2016-06.xsd"
     convert_schema(url=xsd, target_dir=target_dir)
@@ -47,12 +53,14 @@ SHOULD_RAISE = {"bad"}
 
 
 def mark_xfail(fname):
+    return fname
     return pytest.param(
         fname,
         marks=pytest.mark.xfail(
             strict=True, reason="Unexpected success. You fixed it!"
         ),
     )
+
 
 def true_stem(p):
     return p.name.partition(".")[0]
@@ -66,6 +74,8 @@ params = [
 
 @pytest.mark.parametrize("xml", params, ids=true_stem)
 def test_convert_schema(model, xml):
+    from ome_types import from_xml
+
     if true_stem(xml) in SHOULD_RAISE:
         with pytest.raises(XMLSchemaValidationError):
             assert from_xml(xml, model.OME)


### PR DESCRIPTION
This adds a `--nogen` option to the pytest command that lets you run tests on the pregenerated model code.  So you can:
1. run `python -m ome_autogen` to generate the model
2. muck about manually with the generated model at `src/ome_types/model`
3. run pytest with `pytest --nogen` to test against your manually edited code.
   - ... use `pytest --nogen --runxfail` to see errors on skipped files
   - ... use (e.g.)  `pytest --nogen --runxfail -k spim` to test a single xml
