### PR TITLE
make IDs optional, add ome_dataclass decorator

### DIFF
--- a/src/ome_autogen.py
+++ b/src/ome_autogen.py
@@ -203,7 +203,7 @@ OVERRIDES = {
             from typing import Optional
             from .simple_types import UniversallyUniqueIdentifier
 
-            @dataclass
+            @ome_dataclass
             class UUID:
                 file_name: str
                 value: UniversallyUniqueIdentifier
@@ -251,7 +251,7 @@ def local_import(item_type: str) -> str:
 
 
 def make_dataclass(component: Union[XsdComponent, XsdType]) -> List[str]:
-    lines = ["from pydantic.dataclasses import dataclass", ""]
+    lines = ["from ome_types.dataclasses import ome_dataclass", ""]
     # FIXME: Refactor to remove BinData special-case.
     if component.local_name == "BinData":
         base_type = None
@@ -283,7 +283,7 @@ def make_dataclass(component: Union[XsdComponent, XsdType]) -> List[str]:
     if cannot_have_required_args:
         lines += ["_no_default = object()", ""]
 
-    lines += ["@dataclass", f"class {component.local_name}{base_name}:"]
+    lines += ["@ome_dataclass", f"class {component.local_name}{base_name}:"]
     # FIXME: Refactor to remove BinData special-case.
     if component.local_name == "BinData":
         lines.append("    value: str")
@@ -537,6 +537,8 @@ class Member:
     @property
     def is_optional(self) -> bool:
         # FIXME: hack.  doesn't fully capture the restriction
+        if self.identifier == "id":
+            return True
         if getattr(self.component.parent, "model", "") == "choice":
             return True
         if hasattr(self.component, "min_occurs"):

--- a/src/ome_types/dataclasses.py
+++ b/src/ome_types/dataclasses.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+from pydantic.dataclasses import _process_class
+from pydantic import validator
+
+from typing import TYPE_CHECKING, Any, Callable, Optional, Type, Union
+
+
+if TYPE_CHECKING:
+    from pydantic.dataclasses import DataclassType
+
+
+@validator("id", pre=True, always=True)
+def validate_id(cls: Type[Any], value: Any) -> str:
+    from typing import ClassVar, Set, Union
+
+    # get the required LSID type from the annotation
+    id_type = cls.__annotations__.get("id")
+    # (it will likely be an Optional[LSID])
+    if getattr(id_type, "__origin__", None) is Union:
+        id_type = getattr(id_type, "__args__")[0]
+    if not id_type:
+        return value
+
+    if not hasattr(cls, "_global_ids"):
+        cls._global_ids = set()
+        cls.__annotations__["_global_ids"] = ClassVar[Set[str]]
+
+    id_string = id_type.__name__[:-2]
+    if not value:
+        suffixes = [i.split(":")[-1] for i in cls._global_ids]
+        max_id = max({int(s) for s in suffixes if s.isdigit()} or {0})
+        new_id = f"{id_string}:{max_id + 1}"
+    else:
+        new_id = f"{id_string}:{value}" if isinstance(value, int) else str(value)
+
+    cls._global_ids.add(new_id)
+    return id_type(new_id)
+
+
+def ome_dataclass(
+    _cls: Optional[Type[Any]] = None,
+    *,
+    init: bool = True,
+    repr: bool = True,
+    eq: bool = True,
+    order: bool = False,
+    unsafe_hash: bool = False,
+    frozen: bool = False,
+    config: Type[Any] = None,
+) -> Union[Callable[[Type[Any]], DataclassType], DataclassType]:
+    """Wrapper on the pydantic dataclass decorator.
+
+    Provides OME-specific methods and validators.
+    """
+    if "id" in getattr(_cls, "__annotations__", {}):
+        setattr(_cls, "validate_id", validate_id)
+        if not hasattr(_cls, "id"):
+            setattr(_cls, "id", None)
+
+    def wrap(cls: Type[Any]) -> DataclassType:
+        return _process_class(cls, init, repr, eq, order, unsafe_hash, frozen, config)
+
+    return wrap if _cls is None else wrap(_cls)


### PR DESCRIPTION
This PR has us use our own `@ome_dataclass` decorator, which is a wrapper around `pydantic.dataclasses.dataclass`.  I've been working with custom dataclass decorators in napari recently and finding it useful/powerful.

This PR makes all of the "ID" fields optional, and if they are not provided, a valid ID will be autogenerated, incrementing from the previous IDs.  If one is provided, it is validated as usual.
```python
In [1]: from ome_types.model import Instrument   

In [2]: i = Instrument()  

In [3]: i.id                           
Out[3]: 'Instrument:1'
```

we could probably use this pattern to move other things from the `autogen.py`