### PR TITLE
better non-default in subclass solution

### DIFF
--- a/src/ome_types/dataclasses.py
+++ b/src/ome_types/dataclasses.py
@@ -55,7 +55,7 @@ def modify_post_init(_cls: Type[Any]) -> None:
             nmissed = len(missed)
             s = "s" if nmissed > 1 else ""
             raise TypeError(
-                f"__init__ missing {nmissed} required argument{s}: {missed!r}"
+                f"__init__ missing {nmissed} required argument{s}: {sorted(missed)!r}"
             )
         if origin_post_init is not None:
             origin_post_init(self, *args)

--- a/src/ome_types/dataclasses.py
+++ b/src/ome_types/dataclasses.py
@@ -57,7 +57,7 @@ def modify_post_init(_cls: Type[Any]) -> None:
             raise TypeError(
                 f"__init__ missing {nmissed} required argument{s}: {missed!r}"
             )
-        if origin_post_init:
+        if origin_post_init is not None:
             origin_post_init(self, *args)
 
     setattr(_cls, "__post_init__", new_post_init)

--- a/src/ome_types/dataclasses.py
+++ b/src/ome_types/dataclasses.py
@@ -1,12 +1,14 @@
 from __future__ import annotations
-from pydantic.dataclasses import _process_class
-from pydantic import validator
 
 from typing import TYPE_CHECKING, Any, Callable, Optional, Type, Union
 
+from pydantic import validator
+from pydantic.dataclasses import _process_class
 
 if TYPE_CHECKING:
     from pydantic.dataclasses import DataclassType
+
+EMPTY = object()
 
 
 @validator("id", pre=True, always=True)
@@ -43,6 +45,24 @@ def validate_id(cls: Type[Any], value: Any) -> str:
     return id_type(value)
 
 
+def modify_post_init(_cls: Type[Any]) -> None:
+    origin_post_init = getattr(_cls, "__post_init__", None)
+    required_fields = {k for k, v in _cls.__dict__.items() if v is EMPTY}
+
+    def new_post_init(self: Any, *args: Any) -> None:
+        missed = {f for f in required_fields if getattr(self, f, None) is EMPTY}
+        if missed:
+            nmissed = len(missed)
+            s = "s" if nmissed > 1 else ""
+            raise TypeError(
+                f"__init__ missing {nmissed} required argument{s}: {missed!r}"
+            )
+        if origin_post_init:
+            origin_post_init(self, *args)
+
+    setattr(_cls, "__post_init__", new_post_init)
+
+
 def ome_dataclass(
     _cls: Optional[Type[Any]] = None,
     *,
@@ -58,12 +78,18 @@ def ome_dataclass(
 
     Provides OME-specific methods and validators.
     """
-    if "id" in getattr(_cls, "__annotations__", {}):
-        setattr(_cls, "validate_id", validate_id)
-        if not hasattr(_cls, "id"):
-            setattr(_cls, "id", None)
 
     def wrap(cls: Type[Any]) -> DataclassType:
+        if "id" in getattr(cls, "__annotations__", {}):
+            setattr(cls, "validate_id", validate_id)
+            if not hasattr(cls, "id"):
+                setattr(cls, "id", None)
+
+        modify_post_init(cls)
+
         return _process_class(cls, init, repr, eq, order, unsafe_hash, frozen, config)
 
     return wrap if _cls is None else wrap(_cls)
+
+
+__all__ = ["EMPTY", "ome_dataclass"]

--- a/testing/test_autogen.py
+++ b/testing/test_autogen.py
@@ -64,3 +64,29 @@ def test_convert_schema(model, xml):
             assert from_xml(xml, model.OME)
     else:
         assert from_xml(xml, model.OME)
+
+
+def test_no_id(model):
+    """Test that ids are optional, and auto-increment."""
+    i = model.Instrument()
+    i2 = model.Instrument()
+    assert i.id == "Instrument:1"
+    assert i2.id == "Instrument:2"
+    # ints also work
+    i20 = model.Instrument(id=20)
+    assert i20.id == "Instrument:20"
+
+    # but validation still works
+    with pytest.raises(ValueError):
+        model.Instrument(id="nonsense")
+
+
+def test_required_missing(model):
+    """Test subclasses with non-default arguments still work."""
+    with pytest.raises(TypeError) as e:
+        _ = model.BooleanAnnotation()
+    assert "missing 1 required argument: {'value'}" in str(e)
+
+    with pytest.raises(TypeError) as e:
+        _ = model.Label()
+    assert "missing 2 required arguments: {'y', 'x'}" in str(e)

--- a/testing/test_autogen.py
+++ b/testing/test_autogen.py
@@ -68,13 +68,10 @@ def test_convert_schema(model, xml):
 
 def test_no_id(model):
     """Test that ids are optional, and auto-increment."""
-    i = model.Instrument()
+    i = model.Instrument(id=20)
+    assert i.id == "Instrument:20"
     i2 = model.Instrument()
-    assert i.id == "Instrument:1"
-    assert i2.id == "Instrument:2"
-    # ints also work
-    i20 = model.Instrument(id=20)
-    assert i20.id == "Instrument:20"
+    assert i2.id == "Instrument:21"
 
     # but validation still works
     with pytest.raises(ValueError):
@@ -85,8 +82,8 @@ def test_required_missing(model):
     """Test subclasses with non-default arguments still work."""
     with pytest.raises(TypeError) as e:
         _ = model.BooleanAnnotation()
-    assert "missing 1 required argument: {'value'}" in str(e)
+    assert "missing 1 required argument: ['value']" in str(e)
 
     with pytest.raises(TypeError) as e:
         _ = model.Label()
-    assert "missing 2 required arguments: {'y', 'x'}" in str(e)
+    assert "missing 2 required arguments: ['x', 'y']" in str(e)


### PR DESCRIPTION
This uses the new `@ome_dataclass` decorator to clean up all of the hacks for dataclass inheritance with non-default args.

Used to be:

```python
_no_default = object()

@ome_dataclass
class Point(Shape):
    x: float = _no_default  # type: ignore
    y: float = _no_default  # type: ignore

    # hack for dataclass inheritance with non-default args
    # https://stackoverflow.com/a/53085935/
    def __post_init__(self) -> None:
        if self.y is _no_default:
            raise TypeError("__init__ missing 1 required argument: 'y'")
        if self.x is _no_default:
            raise TypeError("__init__ missing 1 required argument: 'x'")
```

 now is:
```python
from ome_types.dataclasses import EMPTY, ome_dataclass

@ome_dataclass
class Point(Shape):
    x: float = EMPTY  # type: ignore
    y: float = EMPTY  # type: ignore
```