### PR TITLE
improved repr

### DIFF
--- a/coverage.yml
+++ b/coverage.yml
@@ -1,0 +1,9 @@
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 0.5%  # coverage can drop by up to 0.5% while still posting success
+    patch: off
+comment:
+  require_changes: true  # if true: only post the PR comment if coverage changes

--- a/src/ome_types/dataclasses.py
+++ b/src/ome_types/dataclasses.py
@@ -108,8 +108,9 @@ def modify_repr(_cls: Type[Any]) -> None:
                 else:
                     rep = repr(current)
                 lines.append(f"{f.name}={rep},")
-        if lines:
-            lines[-1] = lines[-1].rstrip(",")
+        if len(lines) == 1:
+            body = lines[-1].rstrip(",")
+        elif lines:
             body = "\n" + indent("\n".join(lines), "   ") + "\n"
         else:
             body = ""

--- a/src/ome_types/dataclasses.py
+++ b/src/ome_types/dataclasses.py
@@ -76,8 +76,8 @@ def modify_repr(_cls: Type[Any]) -> None:
         for f in fields(self):
             if f.name == "id":
                 continue
-            if f.default_factory is not MISSING:
-                default = f.default_factory()
+            if f.default_factory is not MISSING:  # type: ignore
+                default = f.default_factory()  # type: ignore
             else:
                 default = f.default
             value = getattr(self, f.name)
@@ -85,8 +85,7 @@ def modify_repr(_cls: Type[Any]) -> None:
                 if isinstance(value, Enum):
                     value = repr(value.value)
                 if isinstance(value, Sequence) and not isinstance(value, str):
-                    lines.append(f"<{len(value)} {f.name.title()}>")
-                    continue
+                    value = f"<{len(value)} {f.name.title()}>"
                 lines.append(f"{f.name}={value}")
         out = name + "\n"
         out += indent("\n".join(lines), "   ")


### PR DESCRIPTION
closes #4
This is a start on improved reprs, as per #4 (leave out properties that are set to the default, summarize containers rather than recursively include their contents) plenty to discuss here...
here's an `Image` repr as it stands:

```
Image:0
   pixels=Pixels:0:0
      dimension_order='XYCZT'
      size_c=2
      size_t=2
      size_x=6
      size_y=4
      size_z=2
      type='uint8'
      bin_data=<8 Bin_Data>
      channels=<2 Channels>
      physical_size_x=10000.0
      physical_size_y=10000.0
      planes=<8 Planes>
   acquisition_date=2010-11-10 14:42:38
   annotation_ref=<4 Annotation_Ref>
   instrument_ref=Instrument:SpimSampleMicroscope1

   name=Spim Sample Tile 1 Angle 1
   objective_settings=Objective:1
      correction_collar=6.0
      medium='Oil'
   stage_label=StageLabel
      name=(1,1) of 1x2
      x=1.0
      y=1.0
```

<details>

<summary>previously...</summary>

:joy:

```
Image(pixels=Pixels(dimension_order=<DimensionOrder.XYCZT: 'XYCZT'>,
size_c=2, size_t=2, size_x=6, size_y=4, size_z=2, type=<PixelType.UINT8:
'uint8'>, big_endian=None,
bin_data=[BinData(value='/wCrzur//wB5oMPi/wBIbJO3AP8ePGCF', big_endian=False,
length=32, compression=<Compression.NONE: 'none'>),
BinData(value='/wCrzur//wB5oMPi/wBIbJO3AP8ePGCF', big_endian=False, length=32,
compression=<Compression.NONE: 'none'>),
BinData(value='/wCrzur//wB5oMPi/wBIbJO3AP8ePGCF', big_endian=False, length=32,
compression=<Compression.NONE: 'none'>),
BinData(value='/wCrzur//wB5oMPi/wBIbJO3AP8ePGCF', big_endian=False, length=32,
compression=<Compression.NONE: 'none'>),
BinData(value='/wCrzur//wB5oMPi/wBIbJO3AP8ePGCF', big_endian=False, length=32,
compression=<Compression.NONE: 'none'>),
BinData(value='/wCrzur//wB5oMPi/wBIbJO3AP8ePGCF', big_endian=False, length=32,
compression=<Compression.NONE: 'none'>),
BinData(value='/wCrzur//wB5oMPi/wBIbJO3AP8ePGCF', big_endian=False, length=32,
compression=<Compression.NONE: 'none'>),
BinData(value='/wCrzur//wB5oMPi/wBIbJO3AP8ePGCF', big_endian=False, length=32,
compression=<Compression.NONE: 'none'>)],
channels=[Channel(acquisition_mode=None, annotation_ref=[], color=-1,
contrast_method=None, detector_settings=None, emission_wavelength=None,
emission_wavelength_unit=<UnitsLength.NANOMETER: 'nm'>,
excitation_wavelength=None, excitation_wavelength_unit=<UnitsLength.NANOMETER:
'nm'>, filter_set_ref=None, fluor='Autofluorescence', id='Channel:0.0',
illumination_type=None, light_path=None, light_source_settings=None, name=None,
nd_filter=None, pinhole_size=None, pinhole_size_unit=<UnitsLength.MICROMETER:
'µm'>, pockel_cell_setting=None, samples_per_pixel=None),
Channel(acquisition_mode=None, annotation_ref=[], color=16711935,
contrast_method=None, detector_settings=None, emission_wavelength=None,
emission_wavelength_unit=<UnitsLength.NANOMETER: 'nm'>,
excitation_wavelength=None, excitation_wavelength_unit=<UnitsLength.NANOMETER:
'nm'>, filter_set_ref=None, fluor='Green-OME', id='Channel:0.1',
illumination_type=None, light_path=None, light_source_settings=None, name=None,
nd_filter=None, pinhole_size=None, pinhole_size_unit=<UnitsLength.MICROMETER:
'µm'>, pockel_cell_setting=None, samples_per_pixel=None)], id='Pixels:0:0',
interleaved=None, metadata_only=False, physical_size_x=10000.0,
physical_size_x_unit=<UnitsLength.MICROMETER: 'µm'>, physical_size_y=10000.0,
physical_size_y_unit=<UnitsLength.MICROMETER: 'µm'>, physical_size_z=None,
physical_size_z_unit=<UnitsLength.MICROMETER: 'µm'>, planes=[Plane(the_c=0,
the_t=0, the_z=0, annotation_ref=[], delta_t=None,
delta_t_unit=<UnitsTime.SECOND: 's'>, exposure_time=500.0,
exposure_time_unit=<UnitsTime.SECOND: 's'>, hash_sha1=None, position_x=None,
position_x_unit=<UnitsLength.REFERENCEFRAME: 'reference frame'>,
position_y=None, position_y_unit=<UnitsLength.REFERENCEFRAME: 'reference
frame'>, position_z=None, position_z_unit=<UnitsLength.REFERENCEFRAME:
'reference frame'>), Plane(the_c=1, the_t=0, the_z=0, annotation_ref=[],
delta_t=None, delta_t_unit=<UnitsTime.SECOND: 's'>, exposure_time=500.0,
exposure_time_unit=<UnitsTime.SECOND: 's'>, hash_sha1=None, position_x=None,
position_x_unit=<UnitsLength.REFERENCEFRAME: 'reference frame'>,
position_y=None, position_y_unit=<UnitsLength.REFERENCEFRAME: 'reference
frame'>, position_z=None, position_z_unit=<UnitsLength.REFERENCEFRAME:
'reference frame'>), Plane(the_c=0, the_t=0, the_z=1, annotation_ref=[],
delta_t=None, delta_t_unit=<UnitsTime.SECOND: 's'>, exposure_time=500.0,
exposure_time_unit=<UnitsTime.SECOND: 's'>, hash_sha1=None, position_x=None,
position_x_unit=<UnitsLength.REFERENCEFRAME: 'reference frame'>,
position_y=None, position_y_unit=<UnitsLength.REFERENCEFRAME: 'reference
frame'>, position_z=None, position_z_unit=<UnitsLength.REFERENCEFRAME:
'reference frame'>), Plane(the_c=1, the_t=0, the_z=1, annotation_ref=[],
delta_t=None, delta_t_unit=<UnitsTime.SECOND: 's'>, exposure_time=500.0,
exposure_time_unit=<UnitsTime.SECOND: 's'>, hash_sha1=None, position_x=None,
position_x_unit=<UnitsLength.REFERENCEFRAME: 'reference frame'>,
position_y=None, position_y_unit=<UnitsLength.REFERENCEFRAME: 'reference
frame'>, position_z=None, position_z_unit=<UnitsLength.REFERENCEFRAME:
'reference frame'>), Plane(the_c=0, the_t=1, the_z=0, annotation_ref=[],
delta_t=None, delta_t_unit=<UnitsTime.SECOND: 's'>, exposure_time=500.0,
exposure_time_unit=<UnitsTime.SECOND: 's'>, hash_sha1=None, position_x=None,
position_x_unit=<UnitsLength.REFERENCEFRAME: 'reference frame'>,
position_y=None, position_y_unit=<UnitsLength.REFERENCEFRAME: 'reference
frame'>, position_z=None, position_z_unit=<UnitsLength.REFERENCEFRAME:
'reference frame'>), Plane(the_c=1, the_t=1, the_z=0, annotation_ref=[],
delta_t=None, delta_t_unit=<UnitsTime.SECOND: 's'>, exposure_time=500.0,
exposure_time_unit=<UnitsTime.SECOND: 's'>, hash_sha1=None, position_x=None,
position_x_unit=<UnitsLength.REFERENCEFRAME: 'reference frame'>,
position_y=None, position_y_unit=<UnitsLength.REFERENCEFRAME: 'reference
frame'>, position_z=None, position_z_unit=<UnitsLength.REFERENCEFRAME:
'reference frame'>), Plane(the_c=0, the_t=1, the_z=1, annotation_ref=[],
delta_t=None, delta_t_unit=<UnitsTime.SECOND: 's'>, exposure_time=500.0,
exposure_time_unit=<UnitsTime.SECOND: 's'>, hash_sha1=None, position_x=None,
position_x_unit=<UnitsLength.REFERENCEFRAME: 'reference frame'>,
position_y=None, position_y_unit=<UnitsLength.REFERENCEFRAME: 'reference
frame'>, position_z=None, position_z_unit=<UnitsLength.REFERENCEFRAME:
'reference frame'>), Plane(the_c=1, the_t=1, the_z=1, annotation_ref=[],
delta_t=None, delta_t_unit=<UnitsTime.SECOND: 's'>, exposure_time=500.0,
exposure_time_unit=<UnitsTime.SECOND: 's'>, hash_sha1=None, position_x=None,
position_x_unit=<UnitsLength.REFERENCEFRAME: 'reference frame'>,
position_y=None, position_y_unit=<UnitsLength.REFERENCEFRAME: 'reference
frame'>, position_z=None, position_z_unit=<UnitsLength.REFERENCEFRAME:
'reference frame'>)], significant_bits=None, tiff_data_blocks=[],
time_increment=None, time_increment_unit=<UnitsTime.SECOND: 's'>),
acquisition_date=datetime.datetime(2010, 11, 10, 14, 42, 38),
annotation_ref=[AnnotationRef(id='Annotation:ExtraStageLabel:1:0'),
AnnotationRef(id='Annotation:SpimSet:1'),
AnnotationRef(id='Annotation:ObjectiveAdditions:1'),
AnnotationRef(id='Annotation:SystemSpecific:1')], description=None,
experiment_ref=None, experimenter_group_ref=None, experimenter_ref=None,
id='Image:0', imaging_environment=None,
instrument_ref=InstrumentRef(id='Instrument:SpimSampleMicroscope1'),
microbeam_manipulation_ref=[], name='Spim Sample Tile 1 Angle 1',
objective_settings=ObjectiveSettings(correction_collar=6.0, id='Objective:1',
medium=<Medium.OIL: 'Oil'>, refractive_index=None), roi_ref=[],
stage_label=StageLabel(name='(1,1) of 1x2', x=1.0,
x_unit=<UnitsLength.REFERENCEFRAME: 'reference frame'>, y=1.0,
y_unit=<UnitsLength.REFERENCEFRAME: 'reference frame'>, z=None,
z_unit=<UnitsLength.REFERENCEFRAME: 'reference frame'>))
```

</details>