### PR TITLE
Update References with pointer to target object

### DIFF
--- a/src/ome_autogen.py
+++ b/src/ome_autogen.py
@@ -252,9 +252,8 @@ CLASS_OVERRIDES = {
         body="""
             def __post_init_post_parse__(self: Any, *args: Any) -> None:
                 ids = collect_ids(self)
-                references = collect_references(self)
-                for ref_id, ref in references.items():
-                    ref.ref_ = weakref.ref(ids[ref_id])
+                for ref in collect_references(self):
+                    ref.ref_ = weakref.ref(ids[ref.id])
         """,
     ),
     "Reference": ClassOverride(

--- a/src/ome_types/dataclasses.py
+++ b/src/ome_types/dataclasses.py
@@ -92,7 +92,7 @@ def modify_post_init(_cls: Type[Any]) -> None:
 def modify_repr(_cls: Type[Any]) -> None:
     """Improved dataclass repr function.
 
-    Only show non-default values, and summarize containers.
+    Only show non-default non-internal values, and summarize containers.
     """
     # let classes still create their own
     if _cls.__repr__ is not object.__repr__:
@@ -102,6 +102,8 @@ def modify_repr(_cls: Type[Any]) -> None:
         name = self.__class__.__qualname__
         lines = []
         for f in sorted(fields(self), key=lambda f: f.name not in ("name", "id")):
+            if f.name.endswith("_"):
+                continue
             # https://github.com/python/mypy/issues/6910
             if f.default_factory is not MISSING:  # type: ignore
                 default = f.default_factory()  # type: ignore

--- a/src/ome_types/util.py
+++ b/src/ome_types/util.py
@@ -1,0 +1,50 @@
+import dataclasses
+import weakref
+from typing import Any, Dict
+
+from .model.simple_types import LSID
+from .model.reference import Reference
+
+
+def collect_references(value: Any) -> Dict[LSID, Reference]:
+    """Return a map of all References contained in value, keyed by id.
+
+    Recursively walks all dataclass fields and iterates over lists. The base
+    case is when value is either a Reference object, or an uninteresting type
+    that we don't need to inspect further.
+
+    """
+    references: Dict[LSID, Reference] = {}
+    if isinstance(value, Reference):
+        references[value.id] = value
+    elif isinstance(value, list):
+        for v in value:
+            references.update(collect_references(v))
+    elif dataclasses.is_dataclass(value):
+        for f in dataclasses.fields(value):
+            references.update(collect_references(getattr(value, f.name)))
+    # Do nothing for uninteresting types
+    return references
+
+
+def collect_ids(value: Any) -> Dict[LSID, Any]:
+    """Return a map of all model objects contained in value, keyed by id.
+
+    Recursively walks all dataclass fields and iterates over lists. The base
+    case is when value is neither a dataclass nor a list.
+
+    """
+    ids: Dict[LSID, Any] = {}
+    if isinstance(value, list):
+        for v in value:
+            ids.update(collect_ids(v))
+    elif dataclasses.is_dataclass(value):
+        for f in dataclasses.fields(value):
+            if f.name == "id" and not isinstance(value, Reference):
+                # We don't need to recurse on the id string, so just record it
+                # and move on.
+                ids[value.id] = value
+            else:
+                ids.update(collect_ids(getattr(value, f.name)))
+    # Do nothing for uninteresting types.
+    return ids

--- a/src/ome_types/util.py
+++ b/src/ome_types/util.py
@@ -1,28 +1,28 @@
 import dataclasses
 import weakref
-from typing import Any, Dict
+from typing import Any, Dict, List
 
 from .model.simple_types import LSID
 from .model.reference import Reference
 
 
-def collect_references(value: Any) -> Dict[LSID, Reference]:
-    """Return a map of all References contained in value, keyed by id.
+def collect_references(value: Any) -> List[Reference]:
+    """Return a list of all References contained in value.
 
     Recursively walks all dataclass fields and iterates over lists. The base
     case is when value is either a Reference object, or an uninteresting type
     that we don't need to inspect further.
 
     """
-    references: Dict[LSID, Reference] = {}
+    references: List[Reference] = []
     if isinstance(value, Reference):
-        references[value.id] = value
+        references.append(value)
     elif isinstance(value, list):
         for v in value:
-            references.update(collect_references(v))
+            references.extend(collect_references(v))
     elif dataclasses.is_dataclass(value):
         for f in dataclasses.fields(value):
-            references.update(collect_references(getattr(value, f.name)))
+            references.extend(collect_references(getattr(value, f.name)))
     # Do nothing for uninteresting types
     return references
 


### PR DESCRIPTION
Adds a `.ref` to all `Reference` subclasses that returns the referenced model
object. There is an underlying `ref_` field to support this that is only filled 
in by the root `OME` object's constructor. A future API addition will be
created to support proper creation of References.

Closes #27 