### PR TITLE
Add _quantity property for values with units

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -30,6 +30,7 @@ python_requires = >=3.7
 install_requires =
     pydantic[email]>=1.0
     xmlschema>=1.0.16
+    Pint>=0.15
 
 [options.package_data]
 * = *.xsd

--- a/testing/test_units.py
+++ b/testing/test_units.py
@@ -1,0 +1,62 @@
+import pytest
+from pydantic import ValidationError
+from pint import DimensionalityError
+from ome_types.model import Channel, Laser, Plane
+from ome_types.dataclasses import ureg
+
+
+def test_quantity_math():
+    """Validate math on quantities with different but compatible units."""
+    channel = Channel(
+        excitation_wavelength=475,
+        excitation_wavelength_unit="nm",
+        emission_wavelength=530000,
+        emission_wavelength_unit="pm",
+    )
+    shift = (
+        channel.emission_wavelength_quantity - channel.excitation_wavelength_quantity
+    )
+    # Compare to a tolerance due to Pint internal factor representation.
+    assert abs(shift.to("nm").m - 55) < 1e-12
+
+
+def test_invalid_unit():
+    """Ensure incompatible units in constructor raises ValidationError."""
+    with pytest.raises(ValidationError):
+        Channel(
+            excitation_wavelength=475, excitation_wavelength_unit="kg",
+        )
+
+
+def test_dimensionality_error():
+    """Ensure math on incompatible units raises DimensionalityError."""
+    laser = Laser(
+        id="LightSource:1",
+        repetition_rate=10,
+        repetition_rate_unit="MHz",
+        wavelength=640,
+    )
+    with pytest.raises(DimensionalityError):
+        laser.repetition_rate_quantity + laser.wavelength_quantity
+
+
+def test_reference_frame():
+    """Validate reference_frame behavior."""
+    plane = Plane(
+        the_c=0,
+        the_t=0,
+        the_z=0,
+        position_x=1,
+        position_x_unit="reference frame",
+        position_y=2,
+        position_y_unit="mm",
+    )
+    # Verify two different ways that reference_frame and length are incompatible.
+    with pytest.raises(DimensionalityError):
+        plane.position_x_quantity + plane.position_y_quantity
+    product = plane.position_x_quantity * plane.position_y_quantity
+    assert not product.check("[area]")
+    # Verify that we can obtain a usable length if we know the conversion factor.
+    conversion_factor = ureg.Quantity(1, "micron/reference_frame")
+    position_x = plane.position_x_quantity * conversion_factor
+    assert position_x.check("[length]")


### PR DESCRIPTION
This still needs tests but I wanted to get your thoughts first. I didn't want to mess with the value fields and `..._unit` fields so I added a parallel property with the `_quantity` suffix for all fields with units.

Ultimately it would be cleaner to replace the value fields with a `pint.Quantity` and hide the `_unit` fields completely (that approach would work especially well for create/modify operations), but I'm not sure how we'd want to do the type annotations in that case. Pint doesn't play so well with typing as it loads unit definitions at runtime -- all you can do is type stuff as `Quantity`. We can definitely get Pydantic to parse quantities and reject incompatible units, but mypy probably won't be any help.

closes #3