### PR TITLE
update isort

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -3,7 +3,7 @@ pygments
 sphinx-rtd-theme==0.5.0
 sphinx-autodoc-typehints
 ipython==7.15.0
-isort<5.0
+isort>=5.0
 black
 numpydoc
 autoflake

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -14,7 +14,7 @@ import os
 import sys
 
 sys.path.insert(0, os.path.abspath("../../src"))
-from ome_types import __version__  # noqa: E402
+from ome_types import __version__  # isort:skip  # noqa
 
 # -- Project information -----------------------------------------------------
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=42", "wheel", "setuptools_scm[toml]>=3.4", "black", "isort<5.0", "xmlschema", "autoflake", "numpydoc", "pydantic"]
+requires = ["setuptools>=42", "wheel", "setuptools_scm[toml]>=3.4", "black", "isort>=5.0", "xmlschema", "autoflake", "numpydoc", "pydantic"]
 build-backend = "setuptools.build_meta"
 
 [tool.check-manifest]
@@ -14,6 +14,7 @@ ignore = [
 [tool.isort]
 profile = "black"
 line_length = 88
+float_to_top = true
 skip_glob = ["*examples/*", "*vendored*"]
 
 [tool.black]

--- a/setup.cfg
+++ b/setup.cfg
@@ -35,7 +35,7 @@ install_requires =
 * = *.xsd
 
 [options.extras_require]
-autogen = isort<5.0; black; autoflake; numpydoc
+autogen = isort>=5.0; black; autoflake; numpydoc
 
 [options.packages.find]
 where=src

--- a/src/ome_autogen.py
+++ b/src/ome_autogen.py
@@ -21,7 +21,7 @@ from typing import (
 )
 
 import black
-import isort
+import isort.api
 from autoflake import fix_code
 from numpydoc.docscrape import NumpyDocString, Parameter
 from xmlschema import XMLSchema, qnames
@@ -290,12 +290,12 @@ def autoflake(text: str, **kwargs: Any) -> str:
     return fix_code(text, **kwargs)
 
 
-def black_format(text: str, line_length: int = 79) -> str:
+def black_format(text: str, line_length: int = 88) -> str:
     return black.format_str(text, mode=black.FileMode(line_length=line_length))
 
 
 def sort_imports(text: str) -> str:
-    return isort.SortImports(file_contents=text).output
+    return isort.api.sort_code_string(text, profile="black", float_to_top=True)
 
 
 def sort_types(el: XsdType) -> str:
@@ -350,7 +350,7 @@ def get_docstring(
         if summary:
             doc = re.sub(r"\.\s", ".\n\n", doc, count=1)
         # textwrap each paragraph seperately
-        paragraphs = ["\n".join(wrap(p.strip(), width=73)) for p in doc.split("\n\n")]
+        paragraphs = ["\n".join(wrap(p.strip(), width=78)) for p in doc.split("\n\n")]
         # join and return
         return "\n\n".join(paragraphs)
     except (AttributeError, IndexError):
@@ -428,6 +428,8 @@ def make_enum(component: XsdComponent) -> List[str]:
     lines += [f"class {name}(Enum):"]
     doc = get_docstring(component, summary=True)
     if doc:
+        if not doc.endswith("."):
+            doc += "."
         doc = f'"""{doc}\n"""\n'
         lines += indent(doc, "    ").splitlines()
     enum_elems = list(_type.elem.iter("enum"))

--- a/src/ome_types/__init__.py
+++ b/src/ome_types/__init__.py
@@ -1,11 +1,14 @@
+import os
+from pathlib import Path
+from typing import Union
+
+from .schema import to_dict, validate
+
 try:
     from ._version import version as __version__
 except ImportError:
     __version__ = "unknown"
 
-import os
-from pathlib import Path
-from typing import Union
 
 try:
     from .model import OME
@@ -14,7 +17,6 @@ except ImportError:
         "Could not import 'ome_types.model.OME'.\nIf you are in a dev environment, "
         "you may need to run 'python -m src.ome_autogen'"
     ) from None
-from .schema import to_dict, validate
 
 __all__ = ["to_dict", "validate", "from_xml"]
 

--- a/src/ome_types/__init__.py
+++ b/src/ome_types/__init__.py
@@ -2,13 +2,10 @@ import os
 from pathlib import Path
 from typing import Union
 
-from .schema import to_dict, validate
-
 try:
     from ._version import version as __version__
 except ImportError:
     __version__ = "unknown"
-
 
 try:
     from .model import OME
@@ -17,6 +14,8 @@ except ImportError:
         "Could not import 'ome_types.model.OME'.\nIf you are in a dev environment, "
         "you may need to run 'python -m src.ome_autogen'"
     ) from None
+from .schema import to_dict, validate  # isort:skip
+
 
 __all__ = ["to_dict", "validate", "from_xml"]
 


### PR DESCRIPTION
updates `isort` to >=5.0
The main change was that [imports are no longer moved to the top](https://pycqa.github.io/isort/docs/upgrade_guides/5.0.0/#imports-no-longer-moved-to-top) ... which we make heavy use of for deduplication of imports.  which is solved with the [`float-to-top` setting](https://pycqa.github.io/isort/docs/configuration/options/#float-to-top)