### PR TITLE
Add to_xml for serializing a model to XML

### DIFF
--- a/src/ome_types/__init__.py
+++ b/src/ome_types/__init__.py
@@ -14,10 +14,9 @@ except ImportError:
         "Could not import 'ome_types.model.OME'.\nIf you are in a dev environment, "
         "you may need to run 'python -m src.ome_autogen'"
     ) from None
-from .schema import to_dict, validate  # isort:skip
+from .schema import to_dict, to_xml, validate  # isort:skip
 
-
-__all__ = ["to_dict", "validate", "from_xml"]
+__all__ = ["to_dict", "validate", "from_xml", "to_xml"]
 
 
 def from_xml(xml: Union[Path, str]) -> OME:  # type: ignore

--- a/src/ome_types/schema.py
+++ b/src/ome_types/schema.py
@@ -214,7 +214,7 @@ class OMEConverter(XMLSchemaConverter):
             else:
                 default = field.default
             value = getattr(obj, name)
-            if value is None or value == default:
+            if value == default:
                 continue
             elif name == "metadata_only" and not value:
                 continue

--- a/src/ome_types/schema.py
+++ b/src/ome_types/schema.py
@@ -1,26 +1,33 @@
-import re
+from collections import defaultdict
+from dataclasses import fields, is_dataclass
+from datetime import datetime
+from enum import Enum
 from functools import lru_cache
 from pathlib import Path
 from typing import Any, Dict, Optional, Union
 from xml.etree import ElementTree
 
 import xmlschema
-from xmlschema.converters import XMLSchemaConverter
+from elementpath.datatypes import DateTime10
+from xmlschema.converters import ElementData, XMLSchemaConverter
 
-from .model import _field_plurals
+from . import util
+from .model import (
+    OME,
+    XMLAnnotation,
+    _camel_to_snake,
+    _plural_to_singular,
+    _singular_to_plural,
+    _snake_to_camel,
+)
 
 URI_OME = "http://www.openmicroscopy.org/Schemas/OME/2016-06"
 NS_OME = "{" + URI_OME + "}"
+SCHEMA_LOC_OME = f"{URI_OME} {URI_OME}/ome.xsd"
+
+NS_XSI = "{http://www.w3.org/2001/XMLSchema-instance}"
 
 __cache__: Dict[str, xmlschema.XMLSchema] = {}
-
-
-def camel_to_snake(name: str) -> str:
-    # https://stackoverflow.com/a/1176023
-    result = re.sub("([A-Z]+)([A-Z][a-z]+)", r"\1_\2", name)
-    result = re.sub("([a-z0-9])([A-Z])", r"\1_\2", result)
-    result = result.lower().replace(" ", "_")
-    return result
 
 
 @lru_cache(maxsize=8)
@@ -74,7 +81,7 @@ class OMEConverter(XMLSchemaConverter):
 
     def map_qname(self, qname: str) -> str:
         name = super().map_qname(qname)
-        return camel_to_snake(name)
+        return _camel_to_snake.get(name, name)
 
     def element_decode(self, data, xsd_element, xsd_type=None, level=0):  # type: ignore
         """Converts a decoded element data to a data structure."""
@@ -135,6 +142,7 @@ class OMEConverter(XMLSchemaConverter):
                 "file_annotation",
                 "list_annotation",
                 "long_annotation",
+                "map_annotation",
                 "tag_annotation",
                 "term_annotation",
                 "timestamp_annotation",
@@ -151,12 +159,82 @@ class OMEConverter(XMLSchemaConverter):
             result = annotations
         if isinstance(result, dict):
             for name in list(result.keys()):
-                plural = _field_plurals.get((xsd_element.local_name, name), None)
+                plural = _singular_to_plural.get((xsd_element.local_name, name), None)
                 if plural:
                     value = result.pop(name)
                     assert isinstance(value, list), "expected list for plural attr"
                     result[plural] = value
         return result
+
+    def element_encode(
+        self, obj: Any, xsd_element: xmlschema.XsdElement, level: int = 0
+    ) -> ElementData:
+        tag = xsd_element.qualified_name
+        if not is_dataclass(obj):
+            if isinstance(obj, datetime):
+                return ElementData(tag, DateTime10.fromdatetime(obj), None, {})
+            elif isinstance(obj, ElementTree.Element):
+                # ElementData can't represent mixed content, so we'll leave this
+                # element empty and fix it up after encoding is complete.
+                return ElementData(tag, None, None, {})
+            elif xsd_element.type.simple_type is not None:
+                return ElementData(tag, obj, None, {})
+            elif xsd_element.local_name == "MetadataOnly":
+                return ElementData(tag, None, None, {})
+            elif xsd_element.local_name in {"Union", "StructuredAnnotations"}:
+                names = [type(v).__name__ for v in obj]
+                content = [(f"{NS_OME}{n}", v) for n, v in zip(names, obj)]
+                return ElementData(tag, None, content, {})
+            else:
+                raise NotImplementedError(
+                    "Encountered a combination of schema element and data type"
+                    " that is not yet supported. Please submit a bug report with"
+                    " the information below:"
+                    f"\n    element: {xsd_element}\n    data type: {type(obj)}"
+                )
+        text = None
+        content = []
+        attributes = {}
+        # FIXME Can we simplify this?
+        tag_index = defaultdict(
+            lambda: -1,
+            ((_camel_to_snake[e.local_name], i) for i, e in enumerate(xsd_element)),
+        )
+        for field in sorted(
+            fields(obj),
+            key=lambda f: tag_index[_plural_to_singular.get(f.name, f.name)],
+        ):
+            name = field.name
+            if name.endswith("_"):
+                continue
+            value = getattr(obj, name)
+            # FIXME skip if field has default value (see repr implmentation)
+            if value is None or value == []:
+                continue
+            elif name == "metadata_only" and not value:
+                continue
+            name = _plural_to_singular.get(name, name)
+            name = _snake_to_camel.get(name, name)
+            if name in xsd_element.attributes:
+                if isinstance(value, Enum):
+                    value = value.value
+                elif isinstance(value, datetime):
+                    value = DateTime10.fromdatetime(value)
+                attributes[name] = value
+            elif name == "Value" and xsd_element.local_name in {"BinData", "UUID", "M"}:
+                text = value
+            else:
+                if not isinstance(value, list) or name in {
+                    "Union",
+                    "StructuredAnnotations",
+                }:
+                    value = [value]
+                if name == "LightSourceGroup":
+                    names = [type(v).__name__ for v in value]
+                else:
+                    names = [name] * len(value)
+                content.extend([(f"{NS_OME}{n}", v) for n, v in zip(names, value)])
+        return ElementData(tag, text, content, attributes)
 
 
 def to_dict(  # type: ignore
@@ -179,3 +257,23 @@ def to_dict(  # type: ignore
             elt = tree.find(f".//{NS_OME}XMLAnnotation[@ID='{aid}']/{NS_OME}Value")
             annotation["value"] = elt
     return result
+
+
+def to_xml_element(ome: OME) -> ElementTree.Element:
+    schema = _build_schema(URI_OME)
+    root = schema.encode(ome, path=f"/{NS_OME}OME", converter=OMEConverter)
+    # Patch up the XML element tree with Element objects from XMLAnnotations to
+    # work around xmlschema's lack of support for mixed content.
+    for oid, obj in util.collect_ids(ome).items():
+        if isinstance(obj, XMLAnnotation):
+            elt = root.find(f".//{NS_OME}XMLAnnotation[@ID='{oid}']/{NS_OME}Value")
+            elt.extend(list(obj.value))
+    root.attrib[f"{NS_XSI}schemaLocation"] = SCHEMA_LOC_OME
+    return root
+
+
+def to_xml(ome: OME) -> str:
+    root = to_xml_element(ome)
+    ElementTree.register_namespace("", URI_OME)
+    xml = ElementTree.tostring(root, "unicode")
+    return xml

--- a/testing/test_model.py
+++ b/testing/test_model.py
@@ -1,15 +1,29 @@
+import re
 from pathlib import Path
+from xml.dom import minidom
+from xml.etree import ElementTree
 
 import pytest
 from xmlschema.validators.exceptions import XMLSchemaValidationError
 
-from ome_types import from_xml, model
+from ome_types import from_xml, model, to_xml
+from ome_types.schema import NS_OME, URI_OME, get_schema
 
-SHOULD_FAIL = {
+SHOULD_FAIL_READ = {
     # Some timestamps have negative years which datetime doesn't support.
     "timestampannotation",
 }
-SHOULD_RAISE = {"bad"}
+SHOULD_RAISE_READ = {"bad"}
+SHOULD_FAIL_ROUNDTRIP = {
+    "spim",
+    "timestampannotation",
+    "timestampannotation-posix-only",
+    "transformations-downgrade",
+    "transformations-upgrade",
+    "xmlannotation-body-space",
+    "xmlannotation-multi-value",
+    "xmlannotation-svg",
+}
 
 
 def mark_xfail(fname):
@@ -25,20 +39,55 @@ def true_stem(p):
     return p.name.partition(".")[0]
 
 
-params = [
-    mark_xfail(f) if true_stem(f) in SHOULD_FAIL else f
-    for f in Path(__file__).parent.glob("data/*.ome.xml")
+all_xml = list((Path(__file__).parent / "data").glob("*.ome.xml"))
+xml_read = [mark_xfail(f) if true_stem(f) in SHOULD_FAIL_READ else f for f in all_xml]
+xml_roundtrip = [
+    mark_xfail(f) if true_stem(f) in SHOULD_FAIL_ROUNDTRIP else f
+    for f in all_xml
+    if true_stem(f) not in SHOULD_FAIL_READ | SHOULD_RAISE_READ
 ]
 
 
-@pytest.mark.parametrize("xml", params, ids=true_stem)
-def test_convert_schema(xml):
+@pytest.mark.parametrize("xml", xml_read, ids=true_stem)
+def test_read(xml):
 
-    if true_stem(xml) in SHOULD_RAISE:
+    if true_stem(xml) in SHOULD_RAISE_READ:
         with pytest.raises(XMLSchemaValidationError):
             assert from_xml(xml)
     else:
         assert from_xml(xml)
+
+
+@pytest.mark.parametrize("xml", xml_roundtrip, ids=true_stem)
+def test_roundtrip(xml):
+    """Ensure we can losslessly round-trip XML through the model and back."""
+    xml = str(xml)
+    schema = get_schema(xml)
+
+    def canonicalize(xml, strip_empty):
+        d = schema.decode(xml, use_defaults=True)
+        # Strip extra whitespace in the schemaLocation value.
+        d["@xsi:schemaLocation"] = re.sub(r"\s+", " ", d["@xsi:schemaLocation"])
+        root = schema.encode(d, path=NS_OME + "OME", use_defaults=True)
+        # These are the tags that appear in the example files with empty
+        # content. Since our round-trip will drop empty elements, we'll need to
+        # strip them from the "original" documents before comparison.
+        if strip_empty:
+            for tag in ("Description", "LightPath", "Map"):
+                for e in root.findall(f".//{NS_OME}{tag}[.='']..."):
+                    e.remove(e.find(f"{NS_OME}{tag}"))
+        # ET.canonicalize can't handle an empty namespace so we need to
+        # re-register the OME namespace with an actual name before calling
+        # tostring.
+        ElementTree.register_namespace("ome", URI_OME)
+        xml_out = ElementTree.tostring(root, "unicode")
+        xml_out = ElementTree.canonicalize(xml_out, strip_text=True)
+        xml_out = minidom.parseString(xml_out).toprettyxml(indent="  ")
+        return xml_out
+
+    original = canonicalize(xml, True)
+    ours = canonicalize(to_xml(from_xml(xml)), False)
+    assert ours == original
 
 
 def test_no_id():

--- a/testing/test_model.py
+++ b/testing/test_model.py
@@ -8,7 +8,6 @@ from ome_types import from_xml, model
 SHOULD_FAIL = {
     # Some timestamps have negative years which datetime doesn't support.
     "timestampannotation",
-    "mapannotation",
 }
 SHOULD_RAISE = {"bad"}
 

--- a/testing/util.py
+++ b/testing/util.py
@@ -1,0 +1,354 @@
+import io
+import re
+from xml.etree.ElementTree import (
+    XMLParser,
+    _namespace_map,
+    _raise_serialization_error,
+    parse,
+)
+
+# --------------------------------------------------------------------
+# Taken from Python 3.8's ElementTree.py.
+
+
+def canonicalize(xml_data=None, *, out=None, from_file=None, **options):
+    """Convert XML to its C14N 2.0 serialised form.
+
+    If *out* is provided, it must be a file or file-like object that receives
+    the serialised canonical XML output (text, not bytes) through its ``.write()``
+    method.  To write to a file, open it in text mode with encoding "utf-8".
+    If *out* is not provided, this function returns the output as text string.
+
+    Either *xml_data* (an XML string) or *from_file* (a file path or
+    file-like object) must be provided as input.
+
+    The configuration options are the same as for the ``C14NWriterTarget``.
+    """
+    if xml_data is None and from_file is None:
+        raise ValueError("Either 'xml_data' or 'from_file' must be provided as input")
+    sio = None
+    if out is None:
+        sio = out = io.StringIO()
+
+    parser = XMLParser(target=C14NWriterTarget(out.write, **options))
+
+    if xml_data is not None:
+        parser.feed(xml_data)
+        parser.close()
+    elif from_file is not None:
+        parse(from_file, parser=parser)
+
+    return sio.getvalue() if sio is not None else None
+
+
+_looks_like_prefix_name = re.compile(r"^\w+:\w+$", re.UNICODE).match
+
+
+class C14NWriterTarget:
+    """
+    Canonicalization writer target for the XMLParser.
+
+    Serialises parse events to XML C14N 2.0.
+
+    The *write* function is used for writing out the resulting data stream
+    as text (not bytes).  To write to a file, open it in text mode with encoding
+    "utf-8" and pass its ``.write`` method.
+
+    Configuration options:
+
+    - *with_comments*: set to true to include comments
+    - *strip_text*: set to true to strip whitespace before and after text content
+    - *rewrite_prefixes*: set to true to replace namespace prefixes by "n{number}"
+    - *qname_aware_tags*: a set of qname aware tag names in which prefixes
+                          should be replaced in text content
+    - *qname_aware_attrs*: a set of qname aware attribute names in which prefixes
+                           should be replaced in text content
+    - *exclude_attrs*: a set of attribute names that should not be serialised
+    - *exclude_tags*: a set of tag names that should not be serialised
+    """
+
+    def __init__(
+        self,
+        write,
+        *,
+        with_comments=False,
+        strip_text=False,
+        rewrite_prefixes=False,
+        qname_aware_tags=None,
+        qname_aware_attrs=None,
+        exclude_attrs=None,
+        exclude_tags=None,
+    ):
+        self._write = write
+        self._data = []
+        self._with_comments = with_comments
+        self._strip_text = strip_text
+        self._exclude_attrs = set(exclude_attrs) if exclude_attrs else None
+        self._exclude_tags = set(exclude_tags) if exclude_tags else None
+
+        self._rewrite_prefixes = rewrite_prefixes
+        if qname_aware_tags:
+            self._qname_aware_tags = set(qname_aware_tags)
+        else:
+            self._qname_aware_tags = None
+        if qname_aware_attrs:
+            self._find_qname_aware_attrs = set(qname_aware_attrs).intersection
+        else:
+            self._find_qname_aware_attrs = None
+
+        # Stack with globally and newly declared namespaces as (uri, prefix) pairs.
+        self._declared_ns_stack = [
+            [
+                ("http://www.w3.org/XML/1998/namespace", "xml"),
+            ]
+        ]
+        # Stack with user declared namespace prefixes as (uri, prefix) pairs.
+        self._ns_stack = []
+        if not rewrite_prefixes:
+            self._ns_stack.append(list(_namespace_map.items()))
+        self._ns_stack.append([])
+        self._prefix_map = {}
+        self._preserve_space = [False]
+        self._pending_start = None
+        self._root_seen = False
+        self._root_done = False
+        self._ignored_depth = 0
+
+    def _iter_namespaces(self, ns_stack, _reversed=reversed):
+        for namespaces in _reversed(ns_stack):
+            if namespaces:  # almost no element declares new namespaces
+                yield from namespaces
+
+    def _resolve_prefix_name(self, prefixed_name):
+        prefix, name = prefixed_name.split(":", 1)
+        for uri, p in self._iter_namespaces(self._ns_stack):
+            if p == prefix:
+                return f"{{{uri}}}{name}"
+        raise ValueError(
+            f'Prefix {prefix} of QName "{prefixed_name}" is not declared in scope'
+        )
+
+    def _qname(self, qname, uri=None):
+        if uri is None:
+            uri, tag = qname[1:].rsplit("}", 1) if qname[:1] == "{" else ("", qname)
+        else:
+            tag = qname
+
+        prefixes_seen = set()
+        for u, prefix in self._iter_namespaces(self._declared_ns_stack):
+            if u == uri and prefix not in prefixes_seen:
+                return f"{prefix}:{tag}" if prefix else tag, tag, uri
+            prefixes_seen.add(prefix)
+
+        # Not declared yet => add new declaration.
+        if self._rewrite_prefixes:
+            if uri in self._prefix_map:
+                prefix = self._prefix_map[uri]
+            else:
+                prefix = self._prefix_map[uri] = f"n{len(self._prefix_map)}"
+            self._declared_ns_stack[-1].append((uri, prefix))
+            return f"{prefix}:{tag}", tag, uri
+
+        if not uri and "" not in prefixes_seen:
+            # No default namespace declared => no prefix needed.
+            return tag, tag, uri
+
+        for u, prefix in self._iter_namespaces(self._ns_stack):
+            if u == uri:
+                self._declared_ns_stack[-1].append((uri, prefix))
+                return f"{prefix}:{tag}" if prefix else tag, tag, uri
+
+        raise ValueError(f'Namespace "{uri}" is not declared in scope')
+
+    def data(self, data):
+        if not self._ignored_depth:
+            self._data.append(data)
+
+    def _flush(self, _join_text="".join):
+        data = _join_text(self._data)
+        del self._data[:]
+        if self._strip_text and not self._preserve_space[-1]:
+            data = data.strip()
+        if self._pending_start is not None:
+            args, self._pending_start = self._pending_start, None
+            qname_text = data if data and _looks_like_prefix_name(data) else None
+            self._start(*args, qname_text)
+            if qname_text is not None:
+                return
+        if data and self._root_seen:
+            self._write(_escape_cdata_c14n(data))
+
+    def start_ns(self, prefix, uri):
+        if self._ignored_depth:
+            return
+        # we may have to resolve qnames in text content
+        if self._data:
+            self._flush()
+        self._ns_stack[-1].append((uri, prefix))
+
+    def start(self, tag, attrs):
+        if self._exclude_tags is not None and (
+            self._ignored_depth or tag in self._exclude_tags
+        ):
+            self._ignored_depth += 1
+            return
+        if self._data:
+            self._flush()
+
+        new_namespaces = []
+        self._declared_ns_stack.append(new_namespaces)
+
+        if self._qname_aware_tags is not None and tag in self._qname_aware_tags:
+            # Need to parse text first to see if it requires a prefix declaration.
+            self._pending_start = (tag, attrs, new_namespaces)
+            return
+        self._start(tag, attrs, new_namespaces)
+
+    def _start(self, tag, attrs, new_namespaces, qname_text=None):
+        if self._exclude_attrs is not None and attrs:
+            attrs = {k: v for k, v in attrs.items() if k not in self._exclude_attrs}
+
+        qnames = {tag, *attrs}
+        resolved_names = {}
+
+        # Resolve prefixes in attribute and tag text.
+        if qname_text is not None:
+            qname = resolved_names[qname_text] = self._resolve_prefix_name(qname_text)
+            qnames.add(qname)
+        if self._find_qname_aware_attrs is not None and attrs:
+            qattrs = self._find_qname_aware_attrs(attrs)
+            if qattrs:
+                for attr_name in qattrs:
+                    value = attrs[attr_name]
+                    if _looks_like_prefix_name(value):
+                        qname = resolved_names[value] = self._resolve_prefix_name(value)
+                        qnames.add(qname)
+            else:
+                qattrs = None
+        else:
+            qattrs = None
+
+        # Assign prefixes in lexicographical order of used URIs.
+        parse_qname = self._qname
+        parsed_qnames = {
+            n: parse_qname(n) for n in sorted(qnames, key=lambda n: n.split("}", 1))
+        }
+
+        # Write namespace declarations in prefix order ...
+        if new_namespaces:
+            attr_list = [
+                ("xmlns:" + prefix if prefix else "xmlns", uri)
+                for uri, prefix in new_namespaces
+            ]
+            attr_list.sort()
+        else:
+            # almost always empty
+            attr_list = []
+
+        # ... followed by attributes in URI+name order
+        if attrs:
+            for k, v in sorted(attrs.items()):
+                if qattrs is not None and k in qattrs and v in resolved_names:
+                    v = parsed_qnames[resolved_names[v]][0]
+                attr_qname, attr_name, uri = parsed_qnames[k]
+                # No prefix for attributes in default ('') namespace.
+                attr_list.append((attr_qname if uri else attr_name, v))
+
+        # Honour xml:space attributes.
+        space_behaviour = attrs.get("{http://www.w3.org/XML/1998/namespace}space")
+        self._preserve_space.append(
+            space_behaviour == "preserve"
+            if space_behaviour
+            else self._preserve_space[-1]
+        )
+
+        # Write the tag.
+        write = self._write
+        write("<" + parsed_qnames[tag][0])
+        if attr_list:
+            write("".join([f' {k}="{_escape_attrib_c14n(v)}"' for k, v in attr_list]))
+        write(">")
+
+        # Write the resolved qname text content.
+        if qname_text is not None:
+            write(_escape_cdata_c14n(parsed_qnames[resolved_names[qname_text]][0]))
+
+        self._root_seen = True
+        self._ns_stack.append([])
+
+    def end(self, tag):
+        if self._ignored_depth:
+            self._ignored_depth -= 1
+            return
+        if self._data:
+            self._flush()
+        self._write(f"</{self._qname(tag)[0]}>")
+        self._preserve_space.pop()
+        self._root_done = len(self._preserve_space) == 1
+        self._declared_ns_stack.pop()
+        self._ns_stack.pop()
+
+    def comment(self, text):
+        if not self._with_comments:
+            return
+        if self._ignored_depth:
+            return
+        if self._root_done:
+            self._write("\n")
+        elif self._root_seen and self._data:
+            self._flush()
+        self._write(f"<!--{_escape_cdata_c14n(text)}-->")
+        if not self._root_seen:
+            self._write("\n")
+
+    def pi(self, target, data):
+        if self._ignored_depth:
+            return
+        if self._root_done:
+            self._write("\n")
+        elif self._root_seen and self._data:
+            self._flush()
+        self._write(
+            f"<?{target} {_escape_cdata_c14n(data)}?>" if data else f"<?{target}?>"
+        )
+        if not self._root_seen:
+            self._write("\n")
+
+
+def _escape_cdata_c14n(text):
+    # escape character data
+    try:
+        # it's worth avoiding do-nothing calls for strings that are
+        # shorter than 500 character, or so.  assume that's, by far,
+        # the most common case in most applications.
+        if "&" in text:
+            text = text.replace("&", "&amp;")
+        if "<" in text:
+            text = text.replace("<", "&lt;")
+        if ">" in text:
+            text = text.replace(">", "&gt;")
+        if "\r" in text:
+            text = text.replace("\r", "&#xD;")
+        return text
+    except (TypeError, AttributeError):
+        _raise_serialization_error(text)
+
+
+def _escape_attrib_c14n(text):
+    # escape attribute value
+    try:
+        if "&" in text:
+            text = text.replace("&", "&amp;")
+        if "<" in text:
+            text = text.replace("<", "&lt;")
+        if '"' in text:
+            text = text.replace('"', "&quot;")
+        if "\t" in text:
+            text = text.replace("\t", "&#x9;")
+        if "\n" in text:
+            text = text.replace("\n", "&#xA;")
+        if "\r" in text:
+            text = text.replace("\r", "&#xD;")
+        return text
+    except (TypeError, AttributeError):
+        _raise_serialization_error(text)


### PR DESCRIPTION
Now with backport of `ElementTree.canonicalize` from 3.8!