### PR TITLE
add & skip failing test

### DIFF
--- a/testing/data/tubhiswt.ome.xml
+++ b/testing/data/tubhiswt.ome.xml
@@ -1,0 +1,192 @@
+<?xml version="1.0" encoding="UTF-8"?><!-- Warning: this comment is an OME-XML metadata block, which contains crucial dimensional parameters and other important metadata. Please edit cautiously (if at all), and back up the original data before doing so. For more information, see the OME-TIFF web site: http://www.openmicroscopy.org/site/support/ome-model/ome-tiff/. -->
+<OME xmlns="http://www.openmicroscopy.org/Schemas/OME/2016-06"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" Creator="OME Bio-Formats 5.2.0-m4" UUID="urn:uuid:06846f98-85ab-43f1-b665-2ba8b11ca845" xsi:schemaLocation="http://www.openmicroscopy.org/Schemas/OME/2016-06 http://www.openmicroscopy.org/Schemas/OME/2016-06/ome.xsd">
+    <Experiment ID="urn:lsid:loci.wisc.edu:Experiment:OWS350" Type="TimeLapse">
+        <Description>4 Cell Embryo</Description>
+        <ExperimenterRef ID="urn:lsid:loci.wisc.edu:Experimenter:116"/>
+    </Experiment>
+    <Experimenter Email="mnasim@wisc.edu" FirstName="Maimoon" ID="urn:lsid:loci.wisc.edu:Experimenter:116" Institution="" LastName="Nasim"/>
+    <Instrument ID="urn:lsid:loci.wisc.edu:Instrument:OWS1">
+        <Microscope Manufacturer="Nikon" Model="Eclipse TE300" SerialNumber="U629762" Type="Inverted"/>
+        <Laser ID="urn:lsid:loci.wisc.edu:LightSource:OWS1" LaserMedium="TiSapphire" Manufacturer="Spectral Physics" Model="Tsunami 5W" SerialNumber="2123" Type="SolidState"/>
+        <Detector ID="urn:lsid:loci.wisc.edu:Detector:OWS1" Manufacturer="Hamamatzu" Model="H7422" Type="PMT"/>
+        <Detector ID="urn:lsid:loci.wisc.edu:Detector:OWS2" Manufacturer="Bio-Rad" Model="1024TLD" Type="Photodiode"/>
+        <Objective CalibratedMagnification="100.0" Correction="PlanApo" ID="urn:lsid:loci.wisc.edu:Objective:OWS2" Immersion="Oil" LensNA="1.4" Manufacturer="Nikon" Model="S Fluor" NominalMagnification="100.0" SerialNumber="044989" WorkingDistance="0.13" WorkingDistanceUnit="µm"/>
+    </Instrument>
+    <Image ID="Image:0" Name="tubhiswt">
+        <AcquisitionDate>2013-01-15T17:02:41</AcquisitionDate>
+        <ExperimenterRef ID="urn:lsid:loci.wisc.edu:Experimenter:116"/>
+        <Pixels BigEndian="false" DimensionOrder="XYZTC" ID="Pixels:0" Interleaved="false" SignificantBits="8" SizeC="2" SizeT="20" SizeX="512" SizeY="512" SizeZ="1" Type="uint8">
+            <Channel Color="-1" ID="Channel:0:0" SamplesPerPixel="1">
+                <LightSourceSettings ID="urn:lsid:loci.wisc.edu:LightSource:OWS1"/>
+                <DetectorSettings ID="urn:lsid:loci.wisc.edu:Detector:OWS1"/>
+                <LightPath/>
+            </Channel>
+            <Channel Color="-1" ID="Channel:0:1" SamplesPerPixel="1">
+                <LightSourceSettings ID="urn:lsid:loci.wisc.edu:LightSource:OWS1"/>
+                <DetectorSettings ID="urn:lsid:loci.wisc.edu:Detector:OWS2"/>
+                <LightPath/>
+            </Channel>
+            <TiffData FirstC="0" FirstT="0" FirstZ="0" IFD="0" PlaneCount="1">
+                <UUID FileName="tubhiswt_C0.ome.tif">urn:uuid:06846f98-85ab-43f1-b665-2ba8b11ca845</UUID>
+            </TiffData>
+            <TiffData FirstC="0" FirstT="1" FirstZ="0" IFD="1" PlaneCount="1">
+                <UUID FileName="tubhiswt_C0.ome.tif">urn:uuid:06846f98-85ab-43f1-b665-2ba8b11ca845</UUID>
+            </TiffData>
+            <TiffData FirstC="0" FirstT="2" FirstZ="0" IFD="2" PlaneCount="1">
+                <UUID FileName="tubhiswt_C0.ome.tif">urn:uuid:06846f98-85ab-43f1-b665-2ba8b11ca845</UUID>
+            </TiffData>
+            <TiffData FirstC="0" FirstT="3" FirstZ="0" IFD="3" PlaneCount="1">
+                <UUID FileName="tubhiswt_C0.ome.tif">urn:uuid:06846f98-85ab-43f1-b665-2ba8b11ca845</UUID>
+            </TiffData>
+            <TiffData FirstC="0" FirstT="4" FirstZ="0" IFD="4" PlaneCount="1">
+                <UUID FileName="tubhiswt_C0.ome.tif">urn:uuid:06846f98-85ab-43f1-b665-2ba8b11ca845</UUID>
+            </TiffData>
+            <TiffData FirstC="0" FirstT="5" FirstZ="0" IFD="5" PlaneCount="1">
+                <UUID FileName="tubhiswt_C0.ome.tif">urn:uuid:06846f98-85ab-43f1-b665-2ba8b11ca845</UUID>
+            </TiffData>
+            <TiffData FirstC="0" FirstT="6" FirstZ="0" IFD="6" PlaneCount="1">
+                <UUID FileName="tubhiswt_C0.ome.tif">urn:uuid:06846f98-85ab-43f1-b665-2ba8b11ca845</UUID>
+            </TiffData>
+            <TiffData FirstC="0" FirstT="7" FirstZ="0" IFD="7" PlaneCount="1">
+                <UUID FileName="tubhiswt_C0.ome.tif">urn:uuid:06846f98-85ab-43f1-b665-2ba8b11ca845</UUID>
+            </TiffData>
+            <TiffData FirstC="0" FirstT="8" FirstZ="0" IFD="8" PlaneCount="1">
+                <UUID FileName="tubhiswt_C0.ome.tif">urn:uuid:06846f98-85ab-43f1-b665-2ba8b11ca845</UUID>
+            </TiffData>
+            <TiffData FirstC="0" FirstT="9" FirstZ="0" IFD="9" PlaneCount="1">
+                <UUID FileName="tubhiswt_C0.ome.tif">urn:uuid:06846f98-85ab-43f1-b665-2ba8b11ca845</UUID>
+            </TiffData>
+            <TiffData FirstC="0" FirstT="10" FirstZ="0" IFD="10" PlaneCount="1">
+                <UUID FileName="tubhiswt_C0.ome.tif">urn:uuid:06846f98-85ab-43f1-b665-2ba8b11ca845</UUID>
+            </TiffData>
+            <TiffData FirstC="0" FirstT="11" FirstZ="0" IFD="11" PlaneCount="1">
+                <UUID FileName="tubhiswt_C0.ome.tif">urn:uuid:06846f98-85ab-43f1-b665-2ba8b11ca845</UUID>
+            </TiffData>
+            <TiffData FirstC="0" FirstT="12" FirstZ="0" IFD="12" PlaneCount="1">
+                <UUID FileName="tubhiswt_C0.ome.tif">urn:uuid:06846f98-85ab-43f1-b665-2ba8b11ca845</UUID>
+            </TiffData>
+            <TiffData FirstC="0" FirstT="13" FirstZ="0" IFD="13" PlaneCount="1">
+                <UUID FileName="tubhiswt_C0.ome.tif">urn:uuid:06846f98-85ab-43f1-b665-2ba8b11ca845</UUID>
+            </TiffData>
+            <TiffData FirstC="0" FirstT="14" FirstZ="0" IFD="14" PlaneCount="1">
+                <UUID FileName="tubhiswt_C0.ome.tif">urn:uuid:06846f98-85ab-43f1-b665-2ba8b11ca845</UUID>
+            </TiffData>
+            <TiffData FirstC="0" FirstT="15" FirstZ="0" IFD="15" PlaneCount="1">
+                <UUID FileName="tubhiswt_C0.ome.tif">urn:uuid:06846f98-85ab-43f1-b665-2ba8b11ca845</UUID>
+            </TiffData>
+            <TiffData FirstC="0" FirstT="16" FirstZ="0" IFD="16" PlaneCount="1">
+                <UUID FileName="tubhiswt_C0.ome.tif">urn:uuid:06846f98-85ab-43f1-b665-2ba8b11ca845</UUID>
+            </TiffData>
+            <TiffData FirstC="0" FirstT="17" FirstZ="0" IFD="17" PlaneCount="1">
+                <UUID FileName="tubhiswt_C0.ome.tif">urn:uuid:06846f98-85ab-43f1-b665-2ba8b11ca845</UUID>
+            </TiffData>
+            <TiffData FirstC="0" FirstT="18" FirstZ="0" IFD="18" PlaneCount="1">
+                <UUID FileName="tubhiswt_C0.ome.tif">urn:uuid:06846f98-85ab-43f1-b665-2ba8b11ca845</UUID>
+            </TiffData>
+            <TiffData FirstC="0" FirstT="19" FirstZ="0" IFD="19" PlaneCount="1">
+                <UUID FileName="tubhiswt_C0.ome.tif">urn:uuid:06846f98-85ab-43f1-b665-2ba8b11ca845</UUID>
+            </TiffData>
+            <TiffData FirstC="1" FirstT="0" FirstZ="0" IFD="0" PlaneCount="1">
+                <UUID FileName="tubhiswt_C1.ome.tif">urn:uuid:f801ea0a-e93e-4f4f-99b3-7ecc15048c12</UUID>
+            </TiffData>
+            <TiffData FirstC="1" FirstT="1" FirstZ="0" IFD="1" PlaneCount="1">
+                <UUID FileName="tubhiswt_C1.ome.tif">urn:uuid:f801ea0a-e93e-4f4f-99b3-7ecc15048c12</UUID>
+            </TiffData>
+            <TiffData FirstC="1" FirstT="2" FirstZ="0" IFD="2" PlaneCount="1">
+                <UUID FileName="tubhiswt_C1.ome.tif">urn:uuid:f801ea0a-e93e-4f4f-99b3-7ecc15048c12</UUID>
+            </TiffData>
+            <TiffData FirstC="1" FirstT="3" FirstZ="0" IFD="3" PlaneCount="1">
+                <UUID FileName="tubhiswt_C1.ome.tif">urn:uuid:f801ea0a-e93e-4f4f-99b3-7ecc15048c12</UUID>
+            </TiffData>
+            <TiffData FirstC="1" FirstT="4" FirstZ="0" IFD="4" PlaneCount="1">
+                <UUID FileName="tubhiswt_C1.ome.tif">urn:uuid:f801ea0a-e93e-4f4f-99b3-7ecc15048c12</UUID>
+            </TiffData>
+            <TiffData FirstC="1" FirstT="5" FirstZ="0" IFD="5" PlaneCount="1">
+                <UUID FileName="tubhiswt_C1.ome.tif">urn:uuid:f801ea0a-e93e-4f4f-99b3-7ecc15048c12</UUID>
+            </TiffData>
+            <TiffData FirstC="1" FirstT="6" FirstZ="0" IFD="6" PlaneCount="1">
+                <UUID FileName="tubhiswt_C1.ome.tif">urn:uuid:f801ea0a-e93e-4f4f-99b3-7ecc15048c12</UUID>
+            </TiffData>
+            <TiffData FirstC="1" FirstT="7" FirstZ="0" IFD="7" PlaneCount="1">
+                <UUID FileName="tubhiswt_C1.ome.tif">urn:uuid:f801ea0a-e93e-4f4f-99b3-7ecc15048c12</UUID>
+            </TiffData>
+            <TiffData FirstC="1" FirstT="8" FirstZ="0" IFD="8" PlaneCount="1">
+                <UUID FileName="tubhiswt_C1.ome.tif">urn:uuid:f801ea0a-e93e-4f4f-99b3-7ecc15048c12</UUID>
+            </TiffData>
+            <TiffData FirstC="1" FirstT="9" FirstZ="0" IFD="9" PlaneCount="1">
+                <UUID FileName="tubhiswt_C1.ome.tif">urn:uuid:f801ea0a-e93e-4f4f-99b3-7ecc15048c12</UUID>
+            </TiffData>
+            <TiffData FirstC="1" FirstT="10" FirstZ="0" IFD="10" PlaneCount="1">
+                <UUID FileName="tubhiswt_C1.ome.tif">urn:uuid:f801ea0a-e93e-4f4f-99b3-7ecc15048c12</UUID>
+            </TiffData>
+            <TiffData FirstC="1" FirstT="11" FirstZ="0" IFD="11" PlaneCount="1">
+                <UUID FileName="tubhiswt_C1.ome.tif">urn:uuid:f801ea0a-e93e-4f4f-99b3-7ecc15048c12</UUID>
+            </TiffData>
+            <TiffData FirstC="1" FirstT="12" FirstZ="0" IFD="12" PlaneCount="1">
+                <UUID FileName="tubhiswt_C1.ome.tif">urn:uuid:f801ea0a-e93e-4f4f-99b3-7ecc15048c12</UUID>
+            </TiffData>
+            <TiffData FirstC="1" FirstT="13" FirstZ="0" IFD="13" PlaneCount="1">
+                <UUID FileName="tubhiswt_C1.ome.tif">urn:uuid:f801ea0a-e93e-4f4f-99b3-7ecc15048c12</UUID>
+            </TiffData>
+            <TiffData FirstC="1" FirstT="14" FirstZ="0" IFD="14" PlaneCount="1">
+                <UUID FileName="tubhiswt_C1.ome.tif">urn:uuid:f801ea0a-e93e-4f4f-99b3-7ecc15048c12</UUID>
+            </TiffData>
+            <TiffData FirstC="1" FirstT="15" FirstZ="0" IFD="15" PlaneCount="1">
+                <UUID FileName="tubhiswt_C1.ome.tif">urn:uuid:f801ea0a-e93e-4f4f-99b3-7ecc15048c12</UUID>
+            </TiffData>
+            <TiffData FirstC="1" FirstT="16" FirstZ="0" IFD="16" PlaneCount="1">
+                <UUID FileName="tubhiswt_C1.ome.tif">urn:uuid:f801ea0a-e93e-4f4f-99b3-7ecc15048c12</UUID>
+            </TiffData>
+            <TiffData FirstC="1" FirstT="17" FirstZ="0" IFD="17" PlaneCount="1">
+                <UUID FileName="tubhiswt_C1.ome.tif">urn:uuid:f801ea0a-e93e-4f4f-99b3-7ecc15048c12</UUID>
+            </TiffData>
+            <TiffData FirstC="1" FirstT="18" FirstZ="0" IFD="18" PlaneCount="1">
+                <UUID FileName="tubhiswt_C1.ome.tif">urn:uuid:f801ea0a-e93e-4f4f-99b3-7ecc15048c12</UUID>
+            </TiffData>
+            <TiffData FirstC="1" FirstT="19" FirstZ="0" IFD="19" PlaneCount="1">
+                <UUID FileName="tubhiswt_C1.ome.tif">urn:uuid:f801ea0a-e93e-4f4f-99b3-7ecc15048c12</UUID>
+            </TiffData>
+            <Plane TheC="0" TheT="0" TheZ="0"/>
+            <Plane TheC="0" TheT="1" TheZ="0"/>
+            <Plane TheC="0" TheT="2" TheZ="0"/>
+            <Plane TheC="0" TheT="3" TheZ="0"/>
+            <Plane TheC="0" TheT="4" TheZ="0"/>
+            <Plane TheC="0" TheT="5" TheZ="0"/>
+            <Plane TheC="0" TheT="6" TheZ="0"/>
+            <Plane TheC="0" TheT="7" TheZ="0"/>
+            <Plane TheC="0" TheT="8" TheZ="0"/>
+            <Plane TheC="0" TheT="9" TheZ="0"/>
+            <Plane TheC="0" TheT="10" TheZ="0"/>
+            <Plane TheC="0" TheT="11" TheZ="0"/>
+            <Plane TheC="0" TheT="12" TheZ="0"/>
+            <Plane TheC="0" TheT="13" TheZ="0"/>
+            <Plane TheC="0" TheT="14" TheZ="0"/>
+            <Plane TheC="0" TheT="15" TheZ="0"/>
+            <Plane TheC="0" TheT="16" TheZ="0"/>
+            <Plane TheC="0" TheT="17" TheZ="0"/>
+            <Plane TheC="0" TheT="18" TheZ="0"/>
+            <Plane TheC="0" TheT="19" TheZ="0"/>
+            <Plane TheC="1" TheT="0" TheZ="0"/>
+            <Plane TheC="1" TheT="1" TheZ="0"/>
+            <Plane TheC="1" TheT="2" TheZ="0"/>
+            <Plane TheC="1" TheT="3" TheZ="0"/>
+            <Plane TheC="1" TheT="4" TheZ="0"/>
+            <Plane TheC="1" TheT="5" TheZ="0"/>
+            <Plane TheC="1" TheT="6" TheZ="0"/>
+            <Plane TheC="1" TheT="7" TheZ="0"/>
+            <Plane TheC="1" TheT="8" TheZ="0"/>
+            <Plane TheC="1" TheT="9" TheZ="0"/>
+            <Plane TheC="1" TheT="10" TheZ="0"/>
+            <Plane TheC="1" TheT="11" TheZ="0"/>
+            <Plane TheC="1" TheT="12" TheZ="0"/>
+            <Plane TheC="1" TheT="13" TheZ="0"/>
+            <Plane TheC="1" TheT="14" TheZ="0"/>
+            <Plane TheC="1" TheT="15" TheZ="0"/>
+            <Plane TheC="1" TheT="16" TheZ="0"/>
+            <Plane TheC="1" TheT="17" TheZ="0"/>
+            <Plane TheC="1" TheT="18" TheZ="0"/>
+            <Plane TheC="1" TheT="19" TheZ="0"/>
+        </Pixels>
+    </Image>
+</OME>

--- a/testing/test_model.py
+++ b/testing/test_model.py
@@ -9,6 +9,7 @@ SHOULD_FAIL = {
     # Some timestamps have negative years which datetime doesn't support.
     "timestampannotation",
     "mapannotation",
+    "tubhiswt",
 }
 SHOULD_RAISE = {"bad"}
 


### PR DESCRIPTION
see #45, this just adds the XML extracted from the first dataset [on this page](https://docs.openmicroscopy.org/ome-model/5.6.3/ome-tiff/data.html), and adds it to our `SHOULD_FAIL` tests.