### PR TITLE
fix xsd:list code gen

### DIFF
--- a/src/ome_types/schema.py
+++ b/src/ome_types/schema.py
@@ -221,7 +221,9 @@ class OMEConverter(XMLSchemaConverter):
             name = _plural_to_singular.get(name, name)
             name = _snake_to_camel.get(name, name)
             if name in xsd_element.attributes:
-                if isinstance(value, Enum):
+                if isinstance(value, list):
+                    value = [getattr(i, "value", i) for i in value]
+                elif isinstance(value, Enum):
                     value = value.value
                 elif isinstance(value, datetime):
                     value = DateTime10.fromdatetime(value)

--- a/testing/data/tubhiswt.ome.xml
+++ b/testing/data/tubhiswt.ome.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?><!-- Warning: this comment is an OME-XML metadata block, which contains crucial dimensional parameters and other important metadata. Please edit cautiously (if at all), and back up the original data before doing so. For more information, see the OME-TIFF web site: http://www.openmicroscopy.org/site/support/ome-model/ome-tiff/. -->
 <OME xmlns="http://www.openmicroscopy.org/Schemas/OME/2016-06"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" Creator="OME Bio-Formats 5.2.0-m4" UUID="urn:uuid:06846f98-85ab-43f1-b665-2ba8b11ca845" xsi:schemaLocation="http://www.openmicroscopy.org/Schemas/OME/2016-06 http://www.openmicroscopy.org/Schemas/OME/2016-06/ome.xsd">
-    <Experiment ID="urn:lsid:loci.wisc.edu:Experiment:OWS350" Type="TimeLapse">
+    <Experiment ID="urn:lsid:loci.wisc.edu:Experiment:OWS350" Type="TimeLapse SpectralImaging">
         <Description>4 Cell Embryo</Description>
         <ExperimenterRef ID="urn:lsid:loci.wisc.edu:Experimenter:116"/>
     </Experiment>

--- a/testing/test_model.py
+++ b/testing/test_model.py
@@ -25,7 +25,6 @@ SHOULD_FAIL_ROUNDTRIP = {
     "transformations-downgrade",
     "transformations-upgrade",
     # type Enum not being converted to str
-    "tubhiswt",
 }
 SKIP_ROUNDTRIP = {
     # These have XMLAnnotations with extra namespaces and mixed content, which

--- a/testing/test_model.py
+++ b/testing/test_model.py
@@ -17,7 +17,6 @@ import util  # isort: skip
 SHOULD_FAIL_READ = {
     # Some timestamps have negative years which datetime doesn't support.
     "timestampannotation",
-    "tubhiswt",
 }
 SHOULD_RAISE_READ = {"bad"}
 SHOULD_FAIL_ROUNDTRIP = {
@@ -25,6 +24,8 @@ SHOULD_FAIL_ROUNDTRIP = {
     "timestampannotation-posix-only",
     "transformations-downgrade",
     "transformations-upgrade",
+    # type Enum not being converted to str
+    "tubhiswt",
 }
 SKIP_ROUNDTRIP = {
     # These have XMLAnnotations with extra namespaces and mixed content, which

--- a/testing/test_model.py
+++ b/testing/test_model.py
@@ -24,7 +24,6 @@ SHOULD_FAIL_ROUNDTRIP = {
     "timestampannotation-posix-only",
     "transformations-downgrade",
     "transformations-upgrade",
-    # type Enum not being converted to str
 }
 SKIP_ROUNDTRIP = {
     # These have XMLAnnotations with extra namespaces and mixed content, which


### PR DESCRIPTION
fixes #35, fixes #49 

technically, if the list `item_type` isn't an `Enum`, this probably wouldn't work.  But that doesn't occur in the OME schema, so this solution will suffice for us.

Note: this creates a new problem for XML writing, I'll create a new issue for that.