### PR TITLE
from_tiff convenience function

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -36,6 +36,7 @@ install_requires =
 
 [options.extras_require]
 autogen = isort>=5.0; black; autoflake; numpydoc
+tiff = tifffile>=2019.2.22
 
 [options.packages.find]
 where=src

--- a/setup.cfg
+++ b/setup.cfg
@@ -42,7 +42,7 @@ tiff = tifffile>=2019.2.22
 where=src
 
 [flake8]
-ignore = W503, C901, E501
+ignore = W503, C901, E501, E203
 max-line-length = 88
 
 [mypy]

--- a/src/ome_types/__init__.py
+++ b/src/ome_types/__init__.py
@@ -30,7 +30,7 @@ def from_xml(xml: Union[Path, str]) -> OME:  # type: ignore
 
     Returns
     -------
-    ome: ome_types.OME
+    ome: ome_types.model.ome.OME
         ome_types.OME metadata object
     """
     xml = os.fspath(xml)
@@ -52,7 +52,7 @@ def from_tiff(path: Union[Path, str]) -> OME:
 
     Returns
     -------
-    ome: ome_types.OME
+    ome: ome_types.model.ome.OME
         ome_types.OME metadata object
 
     Raises
@@ -60,7 +60,8 @@ def from_tiff(path: Union[Path, str]) -> OME:
     ValueError
         If the TIFF file has no OME metadata.
     """
-    """Return value of first ImageDescription tag from open TIFF file."""
+
+    # Return value of first ImageDescription tag from open TIFF file.
     fh = Path(path).open(mode="rb")
     offsetsize, offsetformat, tagnosize, tagnoformat, tagsize, codeformat = {
         b"II*\0": (4, "<I", 2, "<H", 12, "<H"),


### PR DESCRIPTION
adds a `from_tiff` convenience to generate an `OME` class from a tiff, using `tifffile`.  
Stopped short of adding `tifffile` to dependencies though (added an extra).  Ideas for extracting XML without `tifffile` welcome.