### PR TITLE
Switch from tifffile to inline TIFF-parsing code

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -42,7 +42,7 @@ tiff = tifffile>=2019.2.22
 where=src
 
 [flake8]
-ignore = W503, C901, E501
+ignore = W503, C901, E501, E203
 max-line-length = 88
 
 [mypy]


### PR DESCRIPTION
Also ignore Flake E203 since Black imposes some patterns that are incompatible
with it (and Black forces formatting for all cases that E203 covers, anyway).

Co-authored-by: Christoph Gohlke <cgohlke@uci.edu>