### PR TITLE
Fix serialization/deserialization of weakrefs

### DIFF
--- a/src/ome_autogen.py
+++ b/src/ome_autogen.py
@@ -269,9 +269,17 @@ CLASS_OVERRIDES = {
         """,
         body="""
             def __post_init_post_parse__(self: Any, *args: Any) -> None:
+                self._link_refs()
+
+            def _link_refs(self):
                 ids = util.collect_ids(self)
                 for ref in util.collect_references(self):
                     ref.ref_ = weakref.ref(ids[ref.id])
+
+            def __setstate__(self: Any, state: Dict[str, Any]) -> None:
+                '''Support unpickle of our weakref references.'''
+                self.__dict__.update(state)
+                self._link_refs()
         """,
     ),
     "Reference": ClassOverride(

--- a/src/ome_autogen.py
+++ b/src/ome_autogen.py
@@ -296,6 +296,27 @@ CLASS_OVERRIDES = {
                 return self.ref_()
         """,
     ),
+    "XMLAnnotation": ClassOverride(
+        body='''
+            def __getstate__(self: Any):
+                """Support pickle of our weakref references."""
+                from ome_types.schema import ElementTree
+
+                d = self.__dict__.copy()
+                d["value"] = ElementTree.tostring(d.pop("value")).strip()
+                return d
+
+            def __setstate__(self: Any, state) -> None:
+                """Support unpickle of our weakref references."""
+                from ome_types.schema import ElementTree
+
+                self.__dict__.update(state)
+                self.value = ElementTree.fromstring(self.value)
+
+            def __eq__(self, o: "XMLAnnotation") -> bool:
+                return self.__getstate__() == o.__getstate__()
+        '''
+    ),
     "BinData": ClassOverride(base_type="object", fields="value: str"),
     "Map": ClassOverride(fields_suppress={"K"}),
     "M": ClassOverride(base_type="object", fields="value: str"),

--- a/src/ome_types/dataclasses.py
+++ b/src/ome_types/dataclasses.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import weakref
 from dataclasses import MISSING, fields
 from datetime import datetime
 from enum import Enum

--- a/src/ome_types/dataclasses.py
+++ b/src/ome_types/dataclasses.py
@@ -161,19 +161,12 @@ def modify_repr(_cls: Type[Any]) -> None:
 
 def __getstate__(self: Any) -> Dict[str, Any]:
     """Support pickle of our weakref references."""
+    # don't do copy unless necessary
     if "ref_" in self.__dict__:
         d = self.__dict__.copy()
-        d["ref_"] = d.pop("ref_")()  # dereference weakref
+        del d["ref_"]  # remove weakref
         return d
     return self.__dict__
-
-
-def __setstate__(self: Any, state: Dict[str, Any]) -> None:
-    """Support unpickle of our weakref references."""
-    self.__dict__.update(state)
-    if "ref_" in self.__dict__:
-        # re-reference weakref
-        self.__dict__["ref_"] = weakref.ref(self.__dict__.pop("ref_"))
 
 
 def ome_dataclass(
@@ -198,8 +191,6 @@ def ome_dataclass(
         modify_post_init(cls)
         if not hasattr(cls, "__getstate__"):
             cls.__getstate__ = __getstate__
-        if not hasattr(cls, "__setstate__"):
-            cls.__setstate__ = __setstate__
         add_quantities(cls)
         if not repr:
             modify_repr(cls)

--- a/src/ome_types/dataclasses.py
+++ b/src/ome_types/dataclasses.py
@@ -1,15 +1,15 @@
 from __future__ import annotations
 
+import weakref
 from dataclasses import MISSING, fields
 from datetime import datetime
 from enum import Enum
 from textwrap import indent
-from typing import TYPE_CHECKING, Any, Callable, Optional, Sequence, Type, Union, Dict
+from typing import TYPE_CHECKING, Any, Callable, Dict, Optional, Sequence, Type, Union
 
 import pint
 from pydantic import validator
 from pydantic.dataclasses import _process_class
-import weakref
 
 if TYPE_CHECKING:
     from pydantic.dataclasses import DataclassType
@@ -196,8 +196,10 @@ def ome_dataclass(
         if getattr(cls, "id", None) is AUTO_SEQUENCE:
             setattr(cls, "validate_id", validate_id)
         modify_post_init(cls)
-        cls.__getstate__ = __getstate__
-        cls.__setstate__ = __setstate__
+        if not hasattr(cls, "__getstate__"):
+            cls.__getstate__ = __getstate__
+        if not hasattr(cls, "__setstate__"):
+            cls.__setstate__ = __setstate__
         add_quantities(cls)
         if not repr:
             modify_repr(cls)

--- a/testing/test_model.py
+++ b/testing/test_model.py
@@ -1,3 +1,4 @@
+import pickle
 import re
 from pathlib import Path
 from xml.dom import minidom
@@ -122,7 +123,8 @@ def test_roundtrip(xml):
 @pytest.mark.parametrize("xml", xml_read, ids=true_stem)
 def test_serialization(xml):
     """Test pickle serialization and reserialization."""
-    import pickle
+    if true_stem(xml) in SHOULD_RAISE_READ:
+        pytest.skip("Can't pickle unreadable xml")
 
     ome = from_xml(xml)
     serialized = pickle.dumps(ome)

--- a/testing/test_model.py
+++ b/testing/test_model.py
@@ -119,6 +119,17 @@ def test_roundtrip(xml):
     assert ours == original
 
 
+@pytest.mark.parametrize("xml", xml_read, ids=true_stem)
+def test_serialization(xml):
+    """Test pickle serialization and reserialization."""
+    import pickle
+
+    ome = from_xml(xml)
+    serialized = pickle.dumps(ome)
+    deserialized = pickle.loads(serialized)
+    assert ome == deserialized
+
+
 def test_no_id():
     """Test that ids are optional, and auto-increment."""
     i = model.Instrument(id=20)

--- a/testing/util.py
+++ b/testing/util.py
@@ -1,8 +1,6 @@
 import io
 import re
-
-# Import ElementTree from one central module to avoid problems passing Elements around,
-from ome_types.schema import ElementTree  # isort: skip
+from xml.etree import ElementTree
 
 # --------------------------------------------------------------------
 # Taken from Python 3.8's ElementTree.py.

--- a/testing/util.py
+++ b/testing/util.py
@@ -1,6 +1,8 @@
 import io
 import re
-from xml.etree import ElementTree
+
+# Import ElementTree from one central module to avoid problems passing Elements around,
+from ome_types.schema import ElementTree  # isort: skip
 
 # --------------------------------------------------------------------
 # Taken from Python 3.8's ElementTree.py.


### PR DESCRIPTION
fixes #60 and pickling of OME objects with weakrefs by adding  `__getstate__` and `__setstate__` methods that de-reference re-reference the weakrefs.

I added tests, and most of them are passing, but a handful of them with xml annotations are still failing with a very weird message:
```
_pickle.PicklingError: Can't pickle <class 'xml.etree.ElementTree.Element'>: it's not the same object as xml.etree.ElementTree.Element
```

furthermore, I don't get that error when I do the test manually in ipython.  @jmuhlich,  would love to hear if you have any thoughts on what might be happening there.