### PR TITLE
feature/pass-kwargs-to-xml

### DIFF
--- a/src/ome_types/schema.py
+++ b/src/ome_types/schema.py
@@ -291,8 +291,23 @@ def to_xml_element(ome: OME) -> ElementTree.Element:
     return root
 
 
-def to_xml(ome: OME) -> str:
+def to_xml(ome: OME, **kwargs: Dict[str, Any]) -> str:
+    """
+    Dump an OME object to string.
+
+    Parameters
+    ----------
+    ome: OME
+        OME object to dump.
+    **kwargs
+        Extra kwargs to pass to ElementTree.tostring.
+
+    Returns
+    -------
+    ome_string: str
+        The XML string of the OME object.
+    """
     root = to_xml_element(ome)
     ElementTree.register_namespace("", URI_OME)
-    xml = ElementTree.tostring(root, "unicode")
+    xml = ElementTree.tostring(root, "unicode", **kwargs)
     return xml

--- a/src/ome_types/schema.py
+++ b/src/ome_types/schema.py
@@ -291,7 +291,7 @@ def to_xml_element(ome: OME) -> ElementTree.Element:
     return root
 
 
-def to_xml(ome: OME, **kwargs: Dict[str, Any]) -> str:
+def to_xml(ome: OME, **kwargs) -> str:  # type: ignore
     """
     Dump an OME object to string.
 

--- a/testing/test_model.py
+++ b/testing/test_model.py
@@ -1,13 +1,14 @@
 import pickle
 import re
 from pathlib import Path
+from unittest import mock
 from xml.dom import minidom
 
 import pytest
 from xmlschema.validators.exceptions import XMLSchemaValidationError
 
 from ome_types import from_tiff, from_xml, model, to_xml
-from ome_types.schema import NS_OME, URI_OME, get_schema
+from ome_types.schema import NS_OME, URI_OME, get_schema, to_xml_element
 
 # Import ElementTree from one central module to avoid problems passing Elements around,
 from ome_types.schema import ElementTree  # isort: skip
@@ -122,13 +123,13 @@ def test_roundtrip(xml):
 
 def test_to_xml_with_kwargs():
     """Ensure kwargs are passed to ElementTree"""
-    # We just need to test with one of them
-    xml = str(xml_roundtrip[0])
-    ome = from_xml(xml)
+    ome = from_xml(Path(__file__).parent / "data" / "example.ome.xml")
 
-    # Use an ElementTree.tostring kwarg and assert that it was passed through
-    rewritten = to_xml(ome, xml_declaration=True)
-    assert rewritten.startswith("<?xml version='1.0' encoding='UTF-8'?>")
+    with mock.patch("xml.etree.ElementTree.tostring") as mocked_et_tostring:
+        element = to_xml_element(ome)
+        # Use an ElementTree.tostring kwarg and assert that it was passed through
+        to_xml(element, xml_declaration=True)
+        assert mocked_et_tostring.call_args.xml_declaration
 
 
 @pytest.mark.parametrize("xml", xml_read, ids=true_stem)

--- a/testing/test_model.py
+++ b/testing/test_model.py
@@ -120,6 +120,17 @@ def test_roundtrip(xml):
     assert ours == original
 
 
+def test_to_xml_with_kwargs():
+    """Ensure kwargs are passed to ElementTree"""
+    # We just need to test with one of them
+    xml = str(xml_roundtrip[0])
+    ome = from_xml(xml)
+
+    # Use an ElementTree.tostring kwarg and assert that it was passed through
+    rewritten = to_xml(ome, xml_declaration=True)
+    assert rewritten.startswith("<?xml version='1.0' encoding='UTF-8'?>")
+
+
 @pytest.mark.parametrize("xml", xml_read, ids=true_stem)
 def test_serialization(xml):
     """Test pickle serialization and reserialization."""


### PR DESCRIPTION
Adding the ability to pass down ElementTree kwargs during `to_xml`. Generally useful but I think most OME XML strings come with the xml declaration so this basically adds that ability.