### PR TITLE
pin xmlschema to 1.4.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,16 +1,26 @@
 [build-system]
-requires = ["setuptools>=42", "wheel", "setuptools_scm[toml]>=3.4", "black", "isort>=5.0", "xmlschema", "autoflake", "numpydoc", "pydantic"]
+requires = [
+  "setuptools>=42",
+  "wheel",
+  "setuptools_scm[toml]>=3.4",
+  "black",
+  "isort>=5.0",
+  "xmlschema==1.4.1",
+  "autoflake",
+  "numpydoc",
+  "pydantic",
+]
 build-backend = "setuptools.build_meta"
 
 [tool.check-manifest]
 ignore = [
-    "*src/ome_types/model/*",
-    "mypy.ini",
-    "coverage.yml",
-    ".pre-commit-config.yaml",
-    "src/ome_autogen.py",
-    ".readthedocs.yml",
-    "src/ome_types/_version.py",  # added by setuptools_scm during build
+  "*src/ome_types/model/*",
+  "mypy.ini",
+  "coverage.yml",
+  ".pre-commit-config.yaml",
+  "src/ome_autogen.py",
+  ".readthedocs.yml",
+  "src/ome_types/_version.py", # added by setuptools_scm during build
 ]
 
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,7 +28,7 @@ include_package_data = true
 python_requires = >=3.7
 install_requires =
     pydantic[email]>=1.0
-    xmlschema>=1.2
+    xmlschema==1.4.1
     Pint>=0.15
 
 [options.package_data]

--- a/src/ome_autogen.py
+++ b/src/ome_autogen.py
@@ -305,25 +305,19 @@ CLASS_OVERRIDES = {
         """,
     ),
     "XMLAnnotation": ClassOverride(
-        body='''
-            def __getstate__(self: Any):
-                """Support pickle of our weakref references."""
-                from ome_types.schema import ElementTree
+        body="""
+            # NOTE: pickling this object requires xmlschema>=1.4.1
+
+            def _to_dict(self):
+                from xml.etree import ElementTree
 
                 d = self.__dict__.copy()
                 d["value"] = ElementTree.tostring(d.pop("value")).strip()
                 return d
 
-            def __setstate__(self: Any, state) -> None:
-                """Support unpickle of our weakref references."""
-                from ome_types.schema import ElementTree
-
-                self.__dict__.update(state)
-                self.value = ElementTree.fromstring(self.value)
-
             def __eq__(self, o: "XMLAnnotation") -> bool:
-                return self.__getstate__() == o.__getstate__()
-        '''
+                return self._to_dict() == o._to_dict()
+        """
     ),
     "BinData": ClassOverride(base_type="object", fields="value: str"),
     "Map": ClassOverride(fields_suppress={"K"}),

--- a/src/ome_types/__init__.py
+++ b/src/ome_types/__init__.py
@@ -10,8 +10,8 @@ except ImportError:
 
 try:
     from .model import OME
-except ImportError:
-    raise ImportError(
+except ModuleNotFoundError:
+    raise ModuleNotFoundError(
         "Could not import 'ome_types.model.OME'.\nIf you are in a dev environment, "
         "you may need to run 'python -m src.ome_autogen'"
     ) from None

--- a/testing/test_model.py
+++ b/testing/test_model.py
@@ -3,18 +3,14 @@ import re
 from pathlib import Path
 from unittest import mock
 from xml.dom import minidom
+from xml.etree import ElementTree
 
 import pytest
+import util
 from xmlschema.validators.exceptions import XMLSchemaValidationError
 
 from ome_types import from_tiff, from_xml, model, to_xml
 from ome_types.schema import NS_OME, URI_OME, get_schema, to_xml_element
-
-# Import ElementTree from one central module to avoid problems passing Elements around,
-from ome_types.schema import ElementTree  # isort: skip
-
-import util  # isort: skip
-
 
 SHOULD_FAIL_READ = {
     # Some timestamps have negative years which datetime doesn't support.


### PR DESCRIPTION
closes #65 by remove pickle patches.  I also realized that xmlschema 1.4.2 has added a number of new issues by extending support for base64 types (and doing some other things with `python_type` that has broken our autogeneration.  so, until I have time to fix that, looks like we're pinned at 1.4.1.

I also tried to address #66 for a bit, but it wasn't as simple as just using `Element` as the type annotation.  will follow up