### PR TITLE
Add a built branch

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,6 +19,7 @@ jobs:
           pip install pep517
           python -m pep517.build -b .
           unzip dist/ome_types-*
+          rm -rf build
       - name: Commit
         uses: EndBug/add-and-commit@v7
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,5 +23,5 @@ jobs:
         uses: EndBug/add-and-commit@v7
         with:
           add: 'ome_types'
-          branch: build
+          branch: tmp
           push: --set-upstream origin build --force

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,5 +23,5 @@ jobs:
         uses: EndBug/add-and-commit@v7
         with:
           add: 'ome_types'
-          branch: tmp
+          branch: build
           push: --set-upstream origin build --force

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ jobs:
           python -m pip install --upgrade pip
           pip install pep517
           python -m pep517.build -b .
-          tar -zxvf dist/ome_types-*
+          unzip dist/ome_types-*
       - name: Commit
         uses: EndBug/add-and-commit@v7
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,5 +24,5 @@ jobs:
         uses: EndBug/add-and-commit@v7
         with:
           add: 'ome_types'
-          branch: build
-          push: --set-upstream origin build --force
+          branch: built
+          push: --set-upstream origin built --force

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,8 +2,8 @@ name: tests
 
 on:
   push:
-    # branches:
-    #   - "master"
+    branches:
+      - "master"
 
 jobs:
   test:
@@ -23,6 +23,6 @@ jobs:
       - name: Commit
         uses: EndBug/add-and-commit@v7
         with:
-          add: 'ome_types'
+          add: "ome_types"
           branch: built
           push: --set-upstream origin built --force

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install pep517
-          python -m pep517.build -b
+          python -m pep517.build -b .
           tar -zxvf dist/ome_types-*
       - name: Commit
         uses: EndBug/add-and-commit@v7

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,4 +24,4 @@ jobs:
         with:
           add: 'ome_types'
           branch: build
-          push: origin build --force
+          push: --set-upstream origin build --force

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,27 @@
+name: tests
+
+on:
+  push:
+    # branches:
+    #   - "master"
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+        with:
+          python-version: 3.9
+      - name: Build
+        run: |
+          python -m pip install --upgrade pip
+          pip install pep517
+          python -m pep517.build -b
+          tar -zxvf dist/ome_types-*
+      - name: Commit
+        uses: EndBug/add-and-commit@v7
+        with:
+          add: 'ome_types'
+          branch: build
+          push: origin build --force


### PR DESCRIPTION
This PR adds a github action that builds the source package and commits to the [`built` branch](https://github.com/tlambert03/ome-types/tree/built).  This makes it easier to link to the autogenerated code, and track how it changes over time.