### PR TITLE
Add aicsimageio test

### DIFF
--- a/.github/scripts/download_aics_test_data.py
+++ b/.github/scripts/download_aics_test_data.py
@@ -1,0 +1,17 @@
+from pathlib import Path
+
+from quilt3 import Package
+
+
+def download_test_resources() -> None:
+    root = Path(__file__).parent.parent.parent
+    resources = (root / "aicsimageio" / "tests" / "resources").resolve()
+    resources.mkdir(exist_ok=True)
+    package = Package.browse(
+        "aicsimageio/test_resources", "s3://aics-modeling-packages-test-resources"
+    )
+    package["resources"].fetch(resources)
+
+
+if __name__ == "__main__":
+    download_test_resources()

--- a/.github/scripts/download_aics_test_data.py
+++ b/.github/scripts/download_aics_test_data.py
@@ -5,9 +5,7 @@ from quilt3 import Package
 
 def download_test_resources() -> None:
     root = Path(__file__).parent.parent.parent
-    print("root is", root)
     resources = (root / "aicsimageio" / "aicsimageio" / "tests" / "resources").resolve()
-    print("resources is", resources)
     resources.mkdir(exist_ok=True)
     package = Package.browse(
         "aicsimageio/test_resources", "s3://aics-modeling-packages-test-resources"

--- a/.github/scripts/download_aics_test_data.py
+++ b/.github/scripts/download_aics_test_data.py
@@ -5,7 +5,9 @@ from quilt3 import Package
 
 def download_test_resources() -> None:
     root = Path(__file__).parent.parent.parent
+    print("root is", root)
     resources = (root / "aicsimageio" / "tests" / "resources").resolve()
+    print("resources is", resources)
     resources.mkdir(exist_ok=True)
     package = Package.browse(
         "aicsimageio/test_resources", "s3://aics-modeling-packages-test-resources"

--- a/.github/scripts/download_aics_test_data.py
+++ b/.github/scripts/download_aics_test_data.py
@@ -6,7 +6,7 @@ from quilt3 import Package
 def download_test_resources() -> None:
     root = Path(__file__).parent.parent.parent
     print("root is", root)
-    resources = (root / "aicsimageio" / "tests" / "resources").resolve()
+    resources = (root / "aicsimageio" / "aicsimageio" / "tests" / "resources").resolve()
     print("resources is", resources)
     resources.mkdir(exist_ok=True)
     package = Package.browse(

--- a/.github/workflows/test_aics.yml
+++ b/.github/workflows/test_aics.yml
@@ -2,11 +2,11 @@ name: test_aics
 
 on:
   push:
-    branches:
-      - "master"
-  pull_request:
-    branches:
-      - "master"
+  #   branches:
+  #     - "master"
+  # pull_request:
+  #   branches:
+  #     - "master"
 
 jobs:
   test:
@@ -28,6 +28,7 @@ jobs:
           cd aicsimageio
           pip install .[test]
           pip install quilt3
-          python scripts/download_test_resources.py --debug
+          python .github/scripts/download_aics_test_data.py
       - name: Run Tests
-        run: pytest
+        run: |
+          pytest aicsimageio/tests/readers/test_ome_tiff_reader.py -v -k "not REMOTE"

--- a/.github/workflows/test_aics.yml
+++ b/.github/workflows/test_aics.yml
@@ -33,14 +33,18 @@ jobs:
           path: aicsimageio/aicsimageio/tests/resources
           key: ${{ runner.os }}-${{ hashFiles('.github/scripts/download_aics_test_data.py') }}
 
-      - name: Install Dependencies
+      - name: Install Test Data
         if: steps.cache.outputs.cache-hit != 'true'
         run: |
           pip install quilt3
           python .github/scripts/download_aics_test_data.py
 
-      - name: Run Tests
+      - name: Install aicsimageio
+        if: steps.cache.outputs.cache-hit != 'true'
         run: |
           cd aicsimageio
           pip install .[test]
+
+      - name: Run Tests
+        run: |
           pytest aicsimageio/tests/readers/test_ome_tiff_reader.py -v -k "not REMOTE"

--- a/.github/workflows/test_aics.yml
+++ b/.github/workflows/test_aics.yml
@@ -18,7 +18,8 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: 3.9
-      - name: Install dependencies
+
+      - name: Install ome-types
         run: |
           python -m pip install --upgrade pip
           pip install .[test]
@@ -47,4 +48,5 @@ jobs:
 
       - name: Run Tests
         run: |
+          cd aicsimageio
           pytest aicsimageio/tests/readers/test_ome_tiff_reader.py -v -k "not REMOTE"

--- a/.github/workflows/test_aics.yml
+++ b/.github/workflows/test_aics.yml
@@ -43,6 +43,4 @@ jobs:
         run: |
           cd aicsimageio
           pip install .[test]
-          ls -la
-          ls aicsimageio -la
           pytest aicsimageio/tests/readers/test_ome_tiff_reader.py -v -k "not REMOTE"

--- a/.github/workflows/test_aics.yml
+++ b/.github/workflows/test_aics.yml
@@ -41,7 +41,6 @@ jobs:
           python .github/scripts/download_aics_test_data.py
 
       - name: Install aicsimageio
-        if: steps.cache.outputs.cache-hit != 'true'
         run: |
           cd aicsimageio
           pip install .[test]

--- a/.github/workflows/test_aics.yml
+++ b/.github/workflows/test_aics.yml
@@ -22,15 +22,27 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install .[test]
+
       - name: Clone aicsimageio
         run: |
-          pwd
           git clone -b main https://github.com/AllenCellModeling/aicsimageio.git
-          ls
+
+      - uses: actions/cache@v2
+        id: cache
+        with:
+          path: aicsimageio/aicsimageio/tests/resources
+          key: ${{ runner.os }}-${{ hashFiles('.github/scripts/download_aics_test_data.py') }}
+
+      - name: Install Dependencies
+        if: steps.cache.outputs.cache-hit != 'true'
+        run: |
           pip install quilt3
           python .github/scripts/download_aics_test_data.py
-          cd aicsimageio
-          pip install .[test]
+
       - name: Run Tests
         run: |
+          cd aicsimageio
+          pip install .[test]
+          ls -la
+          ls aicsimageio -la
           pytest aicsimageio/tests/readers/test_ome_tiff_reader.py -v -k "not REMOTE"

--- a/.github/workflows/test_aics.yml
+++ b/.github/workflows/test_aics.yml
@@ -23,7 +23,7 @@ jobs:
           python -m pip install --upgrade pip
           pip install .[test]
       - name: Clone aicsimageio
-        run:
+        run: |
           git clone -b main https://github.com/AllenCellModeling/aicsimageio.git
           cd aicsimageio
           pip install .[test]

--- a/.github/workflows/test_aics.yml
+++ b/.github/workflows/test_aics.yml
@@ -1,12 +1,10 @@
-name: test_aics
+name: test aicsimageio
 
 on:
   push:
-  #   branches:
-  #     - "master"
-  # pull_request:
-  #   branches:
-  #     - "master"
+    branches:
+      - "master"
+  workflow_dispatch:
 
 jobs:
   test:

--- a/.github/workflows/test_aics.yml
+++ b/.github/workflows/test_aics.yml
@@ -1,0 +1,33 @@
+name: test_aics
+
+on:
+  push:
+    branches:
+      - "master"
+  pull_request:
+    branches:
+      - "master"
+
+jobs:
+  test:
+    name: test aicsimageio
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python 3.9
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.9
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install .[test]
+      - name: Clone aicsimageio
+        run:
+          git clone -b main https://github.com/AllenCellModeling/aicsimageio.git
+          cd aicsimageio
+          pip install .[test]
+          pip install quilt3
+          python scripts/download_test_resources.py --debug
+      - name: Run Tests
+        run: pytest

--- a/.github/workflows/test_aics.yml
+++ b/.github/workflows/test_aics.yml
@@ -24,7 +24,9 @@ jobs:
           pip install .[test]
       - name: Clone aicsimageio
         run: |
+          pwd
           git clone -b main https://github.com/AllenCellModeling/aicsimageio.git
+          ls
           pip install quilt3
           python .github/scripts/download_aics_test_data.py
           cd aicsimageio

--- a/.github/workflows/test_aics.yml
+++ b/.github/workflows/test_aics.yml
@@ -25,10 +25,10 @@ jobs:
       - name: Clone aicsimageio
         run: |
           git clone -b main https://github.com/AllenCellModeling/aicsimageio.git
-          cd aicsimageio
-          pip install .[test]
           pip install quilt3
           python .github/scripts/download_aics_test_data.py
+          cd aicsimageio
+          pip install .[test]
       - name: Run Tests
         run: |
           pytest aicsimageio/tests/readers/test_ome_tiff_reader.py -v -k "not REMOTE"


### PR DESCRIPTION
since aicsimageio is probably one of the main users of this library, it'd be nice to know if I'm breaking anything as I iterate.  This adds a github action that runs some of the [aicsimageio/main](https://github.com/AllenCellModeling/aicsimageio/tree/main) branch tests whenever merging to master.

@JacksonMaxfield and @toloudis, would be good to get your input on this.  At the moment, I'm only running `pytest aicsimageio/tests/readers/test_ome_tiff_reader.py -v -k "not REMOTE"` ... but if you can point me to other tests that might directly or indirectly use `ome-types` functionality i can add them