### PR TITLE
admin/update-build-infra

### DIFF
--- a/.github/scripts/download_aics_test_data.py
+++ b/.github/scripts/download_aics_test_data.py
@@ -6,9 +6,17 @@ from quilt3 import Package
 def download_test_resources() -> None:
     root = Path(__file__).parent.parent.parent
     resources = (root / "aicsimageio" / "aicsimageio" / "tests" / "resources").resolve()
+
+    # Get the specific hash for test resources
+    with open(root / "aicsimageio" / "scripts" / "TEST_RESOURCES_HASH.txt", "r") as f:
+        top_hash = f.readline()
+
+    # Download test resources
     resources.mkdir(exist_ok=True)
     package = Package.browse(
-        "aicsimageio/test_resources", "s3://aics-modeling-packages-test-resources"
+        "aicsimageio/test_resources",
+        "s3://aics-modeling-packages-test-resources",
+        top_hash=top_hash,
     )
     package["resources"].fetch(resources)
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,6 +4,11 @@ on:
   push:
     branches:
       - "master"
+  schedule:
+    # <minute [0,59]> <hour [0,23]> <day of the month [1,31]> <month of the year [1,12]> <day of the week [0,6]>
+    # https://pubs.opengroup.org/onlinepubs/9699919799/utilities/crontab.html#tag_20_25_07
+    # Run every Monday at 18:00:00 UTC (Monday at 10:00:00 PST)
+    - cron: '0 18 * * 1'
 
 jobs:
   build:
@@ -22,6 +27,7 @@ jobs:
           rm -rf build
           rm ome_types/_version.py
       - name: Commit
+        if: github.event_name == 'push'
         uses: EndBug/add-and-commit@v7
         with:
           add: "ome_types"


### PR DESCRIPTION
Adds a CRON schedule to the primary build workflow as an attempt to catch when dependencies release breaking changes.

Also updates the test aics script to use the new top hash file.

Resolves #78 