### PR TITLE
Fix retrieval of non 2016 OME schema

### DIFF
--- a/src/ome_types/schema.py
+++ b/src/ome_types/schema.py
@@ -9,9 +9,10 @@ from xml.etree import ElementTree
 
 import xmlschema
 from elementpath.datatypes import DateTime10
-from xmlschema.converters import ElementData, XMLSchemaConverter
 from xmlschema import XMLSchemaParseError
+from xmlschema.converters import ElementData, XMLSchemaConverter
 from xmlschema.documents import XMLSchemaValueError
+
 from ome_types._base_type import OMEType
 
 from . import util

--- a/src/ome_types/schema.py
+++ b/src/ome_types/schema.py
@@ -10,9 +10,8 @@ from xml.etree import ElementTree
 import xmlschema
 from elementpath.datatypes import DateTime10
 from xmlschema.converters import ElementData, XMLSchemaConverter
-from xmlschema.resources import XMLResource
-from xmlschema.documents import get_context
-
+from xmlschema import XMLSchemaParseError
+from xmlschema.documents import XMLSchemaValueError
 from ome_types._base_type import OMEType
 
 from . import util
@@ -35,12 +34,12 @@ __cache__: Dict[str, xmlschema.XMLSchema] = {}
 
 
 @lru_cache(maxsize=8)
-def _build_schema(resource: XMLResource) -> xmlschema.XMLSchema:
+def _build_schema(ns: str, uri: str = None) -> xmlschema.XMLSchema:
     """Return Schema object for a url.
 
     For the special case of retrieving the 2016-06 OME Schema, use local file.
     """
-    if resource == URI_OME or resource.namespace == URI_OME:
+    if ns == URI_OME:
         schema = xmlschema.XMLSchema(str(Path(__file__).parent / "ome-2016-06.xsd"))
         # FIXME Hack to work around xmlschema poor support for keyrefs to
         # substitution groups
@@ -48,7 +47,7 @@ def _build_schema(resource: XMLResource) -> xmlschema.XMLSchema:
         ls_id_maps = schema.maps.identities[f"{NS_OME}LightSourceIDKey"]
         ls_id_maps.elements = {e: None for e in ls_sgs}
     else:
-        _, schema = get_context(resource)
+        schema = xmlschema.XMLSchema(uri)
     return schema
 
 
@@ -69,7 +68,13 @@ def get_schema(source: Union[xmlschema.XMLResource, str]) -> xmlschema.XMLSchema
     """
     if not isinstance(source, xmlschema.XMLResource):
         source = xmlschema.XMLResource(source)
-    return _build_schema(source)
+
+    for ns, uri in source.get_locations():
+        try:
+            return _build_schema(ns, uri)
+        except XMLSchemaParseError:
+            pass
+    raise XMLSchemaValueError(f"Could not find a schema for XML resource {source!r}.")
 
 
 def validate(xml: str, schema: Optional[xmlschema.XMLSchema] = None) -> None:
@@ -81,8 +86,8 @@ class OMEConverter(XMLSchemaConverter):
     def __init__(
         self, namespaces: Optional[Dict[str, Any]] = None, **kwargs: Dict[Any, Any]
     ):
+        self._ome_ns = ""
         super().__init__(namespaces, attr_prefix="")
-        self._ome_ns = ''
         for name, uri in self._namespaces.items():
             if uri == URI_OME:
                 self._ome_ns = name


### PR DESCRIPTION
partial fix for #88

This fixes the retrieval of a schema for a non 2016  OME schema (but doesn't yet extend support for the 2011 schema)