### PR TITLE
Better abstract "group" types for Instrument and Union

### DIFF
--- a/src/ome_autogen.py
+++ b/src/ome_autogen.py
@@ -120,10 +120,9 @@ OVERRIDES = {
         type_="List[ShapeGroupType]",
         default="Field(default_factory=list)",
         imports="""
-            from typing import Dict, Union, Any, Sequence
+            from typing import Dict, Union, Any, Sequence, Iterator
             from pydantic import validator
 
-            from ..util import _flatten_union_dict
             from .annotation_ref import AnnotationRef
             from .shape_group import ShapeGroupType
             from .simple_types import ROIID
@@ -132,10 +131,20 @@ OVERRIDES = {
             @validator("union", pre=True)
             def _validate_union(cls, value: Any) -> Sequence[Dict[str, Any]]:
                 if isinstance(value, dict):
-                    return list(_flatten_union_dict(value))
+                    return list(cls._flatten_union_dict(value))
                 if not isinstance(value, Sequence):
                     raise TypeError("must be dict or sequence of dicts")
                 return value
+
+            @classmethod
+            def _flatten_union_dict(cls, nested: Dict[str, Any], keyname: str = "kind"
+            ) -> Iterator[Dict[str, Any]]:
+                for key, value in nested.items():
+                    keydict = {keyname: key} if keyname else {}
+                    if isinstance(value, list):
+                        yield from ({**x, **keydict} for x in value)
+                    else:
+                        yield {**value, **keydict}
         """,
     ),
     "OME/StructuredAnnotations": Override(
@@ -328,6 +337,22 @@ CLASS_OVERRIDES = {
     ),
     "GenericExcitationSource": ClassOverride(
         fields='kind: Literal["generic_excitation_source"] = "generic_excitation_source"',
+        imports="from typing_extensions import Literal",
+    ),
+    "Label": ClassOverride(
+        fields='kind: Literal["label"] = "label"',
+        imports="from typing_extensions import Literal",
+    ),
+    "Point": ClassOverride(
+        fields='kind: Literal["point"] = "point"',
+        imports="from typing_extensions import Literal",
+    ),
+    "Mask": ClassOverride(
+        fields='kind: Literal["mask"] = "mask"',
+        imports="from typing_extensions import Literal",
+    ),
+    "Rectangle": ClassOverride(
+        fields='kind: Literal["rectangle"] = "rectangle"',
         imports="from typing_extensions import Literal",
     ),
 }

--- a/src/ome_types/_base_type.py
+++ b/src/ome_types/_base_type.py
@@ -177,3 +177,9 @@ class OMEType(BaseModel, metaclass=OMEMetaclass):
         state = super().__getstate__()
         state["__private_attribute_values__"].pop("_ref", None)
         return state
+
+    @classmethod
+    def snake_name(cls) -> str:
+        from .model import _camel_to_snake
+
+        return _camel_to_snake[cls.__name__]

--- a/src/ome_types/schema.py
+++ b/src/ome_types/schema.py
@@ -160,7 +160,7 @@ class OMEConverter(XMLSchemaConverter):
                 return ElementData(tag, obj, None, {})
             elif xsd_element.local_name == "MetadataOnly":
                 return ElementData(tag, None, None, {})
-            elif xsd_element.local_name in {"StructuredAnnotations"}:
+            elif xsd_element.local_name in {"Union", "StructuredAnnotations"}:
                 names = [type(v).__name__ for v in obj]
                 content = [(f"{NS_OME}{n}", v) for n, v in zip(names, obj)]
                 return ElementData(tag, None, content, {})
@@ -209,6 +209,7 @@ class OMEConverter(XMLSchemaConverter):
                 text = value
             else:
                 if not isinstance(value, list) or name in {
+                    "Union",
                     "StructuredAnnotations",
                 }:
                     value = [value]

--- a/src/ome_types/schema.py
+++ b/src/ome_types/schema.py
@@ -112,44 +112,6 @@ class OMEConverter(XMLSchemaConverter):
         elif xsd_element.local_name == "BinData":
             if result["length"] == 0 and "value" not in result:
                 result["value"] = ""
-        elif xsd_element.local_name == "Instrument":
-            light_sources = []
-            for _type in (
-                "laser",
-                "arc",
-                "filament",
-                "light_emitting_diode",
-                "generic_excitation_source",
-            ):
-                if _type in result:
-                    values = result.pop(_type)
-                    if isinstance(values, dict):
-                        values = [values]
-                    for v in values:
-                        v["_type"] = _type
-                    light_sources.extend(values)
-            if light_sources:
-                result["light_source_group"] = light_sources
-        elif xsd_element.local_name == "Union":
-            shapes = []
-            for _type in (
-                "point",
-                "line",
-                "rectangle",
-                "ellipse",
-                "polyline",
-                "polygon",
-                "mask",
-                "label",
-            ):
-                if _type in result:
-                    values = result.pop(_type)
-                    if isinstance(values, dict):
-                        values = [values]
-                    for v in values:
-                        v["_type"] = _type
-                    shapes.extend(values)
-            result = shapes
         elif xsd_element.local_name == "StructuredAnnotations":
             annotations = []
             for _type in (
@@ -198,7 +160,7 @@ class OMEConverter(XMLSchemaConverter):
                 return ElementData(tag, obj, None, {})
             elif xsd_element.local_name == "MetadataOnly":
                 return ElementData(tag, None, None, {})
-            elif xsd_element.local_name in {"Union", "StructuredAnnotations"}:
+            elif xsd_element.local_name in {"StructuredAnnotations"}:
                 names = [type(v).__name__ for v in obj]
                 content = [(f"{NS_OME}{n}", v) for n, v in zip(names, obj)]
                 return ElementData(tag, None, content, {})
@@ -247,7 +209,6 @@ class OMEConverter(XMLSchemaConverter):
                 text = value
             else:
                 if not isinstance(value, list) or name in {
-                    "Union",
                     "StructuredAnnotations",
                 }:
                     value = [value]

--- a/src/ome_types/util.py
+++ b/src/ome_types/util.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, Iterator, List
+from typing import Any, Dict, List
 
 from ._base_type import OMEType
 from .model.reference import Reference
@@ -47,30 +47,3 @@ def collect_ids(value: Any) -> Dict[LSID, OMEType]:
                 ids.update(collect_ids(getattr(value, f)))
     # Do nothing for uninteresting types.
     return ids
-
-
-def _flatten_union_dict(
-    nested: Dict[str, Any], keyname: str = "type_"
-) -> Iterator[Dict[str, Any]]:
-    """Convert dict of dict-or-list to list of dict.
-
-    (This shows up a lot in Union declarations)
-    {
-        'key1': {...},
-        'key2: [{...}, {...}]
-    }
-
-    returns
-
-    [
-        {..., 'type_': 'key1'},
-        {..., 'type_': 'key2'},
-        {..., 'type_': 'key2'}
-    ]
-    """
-    for key, value in nested.items():
-        keydict = {keyname: key} if keyname else {}
-        if isinstance(value, list):
-            yield from ({**x, **keydict} for x in value)
-        else:
-            yield {**value, **keydict}


### PR DESCRIPTION
This PR makes some changes to the way that Instrument/LightSourceGroup and ROI/Union are parsed.
most importantly, it removes the logic from `schema.element_decode` that prepares the dict "just right" so that it can be parsed by the pydantic model, and puts that logic in the validator on the respective models themselves...

This is working towards being able to support some additional "xml2dict" methods using things besides `xmlschema` (for instance, lxml, which is much faster).