### PR TITLE
Unpin xmlschema, fix for newer versions

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -30,7 +30,7 @@ include_package_data = True
 python_requires = >=3.7
 install_requires =
     pydantic[email]>=1.0
-    xmlschema==1.4.1
+    xmlschema>=1.4.1,<2
     Pint>=0.15
 
 [options.entry_points]

--- a/src/ome_autogen.py
+++ b/src/ome_autogen.py
@@ -29,6 +29,7 @@ from xmlschema import XMLSchema
 from xmlschema.validators import (
     XsdAnyAttribute,
     XsdAnyElement,
+    XsdAtomicBuiltin,
     XsdAttribute,
     XsdComponent,
     XsdElement,
@@ -638,7 +639,7 @@ class Member:
 
     @property
     def is_builtin_type(self) -> bool:
-        return hasattr(self.type, "python_type")
+        return isinstance(self.type, XsdAtomicBuiltin)
 
     @property
     def is_decimal(self) -> bool:
@@ -923,6 +924,15 @@ class GlobalElem:
             return make_color()
         if self.is_enum:
             return make_enum(self.elem)
+        # Hack for xmlschema > 1.4.1
+        if self.type.local_name == "base64Binary":
+            return ["class base64Binary(ConstrainedStr):", "    pass"]
+        if self.type.local_name == "Hex40":
+            return [
+                "class Hex40(ConstrainedStr):",
+                "    min_length = 20",
+                "    max_length = 20",
+            ]
 
         lines = []
         if self.type.base_type.is_restriction():

--- a/src/ome_types/schema.py
+++ b/src/ome_types/schema.py
@@ -9,8 +9,8 @@ from xml.etree import ElementTree
 
 import xmlschema
 from elementpath.datatypes import DateTime10
-from xmlschema import XMLSchemaParseError
-from xmlschema.converters import ElementData, XMLSchemaConverter
+from xmlschema import ElementData, XMLSchemaParseError
+from xmlschema.converters import XMLSchemaConverter
 from xmlschema.documents import XMLSchemaValueError
 
 from ome_types._base_type import OMEType


### PR DESCRIPTION
this finally fixes the autogeneration for xmlschema versions > 1.5 (which changed some things about native python types)