### PR TITLE
build: Remove upper version bound of xmlschema dependency

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -24,7 +24,7 @@ install_requires =
     Pint>=0.15
     lxml>=4.8.0
     pydantic[email]>=1.0
-    xmlschema>=1.4.1,<2
+    xmlschema>=1.4.1
 python_requires = >=3.7
 include_package_data = True
 package_dir =

--- a/src/ome_types/_xmlschema.py
+++ b/src/ome_types/_xmlschema.py
@@ -3,7 +3,7 @@ from collections import defaultdict
 from datetime import datetime
 from enum import Enum
 from functools import lru_cache
-from typing import Any, Dict, Optional, Union
+from typing import Any, Dict, Optional, Tuple, Union
 from xml.etree import ElementTree
 
 import xmlschema
@@ -26,7 +26,7 @@ from .model import (
 )
 
 __cache__: Dict[str, xmlschema.XMLSchema] = {}
-_XMLSCHEMA_VERSION: tuple[int, ...] = tuple(
+_XMLSCHEMA_VERSION: Tuple[int, ...] = tuple(
     int(v) if v.isnumeric() else v for v in xmlschema.__version__.split(".")
 )
 


### PR DESCRIPTION
Hello everyone,

This PR removes the upper version bound of xmlschema and keeps compatibility with `1.x` versions.

Cheers,
Andreas 😃 