### PR TITLE
build: lxml as extra

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -49,7 +49,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install tox tox-gh-actions
-          pip install -e .[autogen]
+          pip install -e .[autogen,lxml]
       - name: Test with tox
         run: tox
         env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -49,7 +49,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install tox tox-gh-actions
-          pip install -e .[autogen,lxml]
+          pip install -e .[autogen]
       - name: Test with tox
         run: tox
         env:

--- a/setup.cfg
+++ b/setup.cfg
@@ -22,7 +22,6 @@ classifiers =
 packages = find:
 install_requires =
     Pint>=0.15
-    lxml>=4.8.0
     pydantic[email]>=1.0
     xmlschema>=1.4.1,<2
 python_requires = >=3.7
@@ -53,6 +52,8 @@ docs =
     pygments
     sphinx==5.3.0
     sphinx-rtd-theme==1.1.1
+lxml =
+    lxml>=4.8.0
 test =
     pytest
     pytest-benchmark

--- a/setup.cfg
+++ b/setup.cfg
@@ -55,6 +55,7 @@ docs =
 lxml =
     lxml>=4.8.0
 test =
+    lxml>=4.8.0
     pytest
     pytest-benchmark
     tox

--- a/src/ome_types/_convenience.py
+++ b/src/ome_types/_convenience.py
@@ -59,7 +59,12 @@ def to_dict(
 
     if isinstance(parser, str):
         if parser == "lxml":
-            from ._lxml import lxml2dict
+            try:
+                from ._lxml import lxml2dict
+            except ImportError:
+                raise ImportError(
+                    "To use `parser='lxml'` run `pip install ome-types[lxml]`"
+                )
 
             parser = cast(Parser, lxml2dict)
         elif parser == "xmlschema":


### PR DESCRIPTION
Hello everyone,

Currently wheels for lxml are still missing for 3.11 on windows and xmlschema only pulls in pure python dependencies.

This PR makes the lxml dependency optional and adds it as an extra.

Let me know if it's worth changing this. I am aware that the warning mentions that `lxml` will be the default with version `0.4.0`. I still think that it's nice if the backend can be chosen explicitly. So it might be worth even making xmlschema an extra to let the user decide what to install and explicitly error in case none are installed. Sadly default extras are still not a thing in the Python packaging world afaik...


Cheers,
Andreas 😃 