### PR TITLE
feat: make lxml optional (but don't yet remove from requirements)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,7 @@ dependencies = [
   "Pint >=0.15",
   "lxml >=4.8.0",
   "pydantic[email] >=1.0",
-  "xmlschema >=1.4.1",
+  "xmlschema >=2.0.0",
 ]
 
 [project.urls]

--- a/src/ome_types/_convenience.py
+++ b/src/ome_types/_convenience.py
@@ -1,11 +1,14 @@
 import os
 from pathlib import Path
-from typing import Any, Dict, Optional, Union, cast
+from typing import TYPE_CHECKING, Any, Dict, Optional, Union, cast
 from warnings import warn
 
 from typing_extensions import Protocol
 
 from .model import OME
+
+if TYPE_CHECKING:
+    from ._xmlschema import XMLSourceType
 
 
 class Parser(Protocol):
@@ -219,7 +222,7 @@ def to_xml(ome: OME, **kwargs: Any) -> str:
     return to_xml(ome, **kwargs)
 
 
-def validate_xml(xml: str, schema: Any = None) -> None:
+def validate_xml(xml: "XMLSourceType", schema: Any = None) -> None:
     from ._xmlschema import validate
 
     validate(xml, schema=schema)

--- a/src/ome_types/_convenience.py
+++ b/src/ome_types/_convenience.py
@@ -60,9 +60,9 @@ def to_dict(
 
     if isinstance(parser, str):
         if parser == "lxml":
-            from ._lxml import lxml2dict
+            from ._lxml import xml2dict
 
-            parser = cast(Parser, lxml2dict)
+            parser = cast(Parser, xml2dict)
         elif parser == "xmlschema":
             from ._xmlschema import xmlschema2dict
 
@@ -70,7 +70,10 @@ def to_dict(
         else:
             raise KeyError("parser string must be one of {'lxml', 'xmlschema'}")
 
-    d = parser(xml) if validate is None else parser(xml, validate=validate)
+    if validate is True:
+        validate_xml(xml)
+
+    d = parser(xml)
     for key in list(d.keys()):
         if key.startswith(("xml", "xsi")):
             d.pop(key)

--- a/src/ome_types/_lxml.py
+++ b/src/ome_types/_lxml.py
@@ -50,11 +50,11 @@ def elem2dict(node: Element, exclude_null: bool = True) -> dict[str, Any]:
     Parameters
     ----------
     node : Element
-        The Element to convert. Should be an `xml.etree.ElementTree.Element` or a 
+        The Element to convert. Should be an `xml.etree.ElementTree.Element` or a
         `lxml.etree._Element`
     exclude_null : bool, optional
         If True, exclude keys with null values from the output.
-    
+
 
     Returns
     -------
@@ -215,13 +215,15 @@ def xml2dict(
     return elem2dict(root)
 
 
-def lxml2dict(*args: Any, **kwargs: Any) -> dict[str, Any]:
-    """Deprecated alias for `xml2dict`."""
-    import warnings
+def __getattr__(name: str) -> Any:
+    """Import lxml if it is not already imported."""
+    if name == "lxml2dict":
+        import warnings
 
-    warnings.warn(
-        "lxml2dict is deprecated, use xml2dict instead",
-        FutureWarning,
-        stacklevel=2,
-    )
-    return xml2dict(*args, **kwargs)
+        warnings.warn(
+            "lxml2dict is deprecated, use xml2dict instead",
+            FutureWarning,
+            stacklevel=2,
+        )
+        return xml2dict
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -1,6 +1,9 @@
+from typing import Callable
 import pytest
 
 from ome_types.model import OME, Channel, Image, Pixels
+from ome_types._lxml import xml2dict
+from ome_types._xmlschema import xmlschema2dict
 
 
 @pytest.mark.parametrize("channel_kwargs", [{}, {"color": "blue"}])

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -1,9 +1,6 @@
-from typing import Callable
 import pytest
 
 from ome_types.model import OME, Channel, Image, Pixels
-from ome_types._lxml import xml2dict
-from ome_types._xmlschema import xmlschema2dict
 
 
 @pytest.mark.parametrize("channel_kwargs", [{}, {"color": "blue"}])


### PR DESCRIPTION
This PR makes slight modifications to the `elem2dict` function that makes it compatible with both lxml as well as standard lib xml.etree elements.  I think the vast majority of the speedup of lxml compared to xmlschema parsing is the lack of schema validation.  (i saw ~25% speedup with lxml over xml.etree ... nice, but shouldn't be mandatory given that lxml can lag behind with updates)

My hope here, in the next couple PRs is to  disconnect the _validation_ of incoming xml from the _parsing_ of xml.  We could make both xmlschema and lxml optional (needed only for validation of an xml instance against the schema ... which we don't particularly need here, given that pydantic will do that on the dict object)