### PR TITLE
fix: fix missing set values in xml output

### DIFF
--- a/src/ome_types/_mixins/_ome.py
+++ b/src/ome_types/_mixins/_ome.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import warnings
 import weakref
-from typing import TYPE_CHECKING, Any, BinaryIO
+from typing import TYPE_CHECKING, Any, BinaryIO, Sequence
 
 from ome_types._mixins._base_type import OMEType
 from ome_types._mixins._ids import CONVERTED_IDS
@@ -55,17 +55,17 @@ def collect_ids(value: Any) -> dict[str, OMEType]:
     from ome_types.model import Reference
 
     ids: dict[str, OMEType] = {}
-    if isinstance(value, list):
+    if isinstance(value, Sequence) and not isinstance(value, str):
         for v in value:
             ids.update(collect_ids(v))
     elif isinstance(value, OMEType):
-        for f in value.__fields__:
-            if f == "id" and not isinstance(value, Reference):
+        for fname in value.__fields__:
+            if fname == "id" and not isinstance(value, Reference):
                 # We don't need to recurse on the id string, so just record it
                 # and move on.
                 ids[value.id] = value
             else:
-                ids.update(collect_ids(getattr(value, f)))
+                ids.update(collect_ids(getattr(value, fname)))
     # Do nothing for uninteresting types.
     return ids
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -145,7 +145,20 @@ def pytest_configure(config: pytest.Config) -> None:
 
 
 @pytest.fixture
-def full_ome_object() -> model.OME:
+def pixels() -> model.Pixels:
+    return model.Pixels(
+        size_c=1,
+        size_t=1,
+        size_z=10,
+        size_x=100,
+        size_y=100,
+        dimension_order="XYZCT",
+        type="uint8",
+    )
+
+
+@pytest.fixture
+def full_ome_object(pixels: model.Pixels) -> model.OME:
     """Mostly used for the omero test, a fully populated OME object."""
     comment_ann = model.CommentAnnotation(value="test comment", id="Annotation:-123")
     comment2 = model.CommentAnnotation(value="test comment", id="Annotation:-1233")
@@ -165,15 +178,7 @@ def full_ome_object() -> model.OME:
     img = model.Image(
         id="Image:0",
         name="MyImage",
-        pixels=model.Pixels(
-            size_c=1,
-            size_t=1,
-            size_z=10,
-            size_x=100,
-            size_y=100,
-            dimension_order="XYZCT",
-            type="uint8",
-        ),
+        pixels=pixels,
         roi_refs=[model.ROIRef(id=roi.id)],
     )
     well = model.Well(

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -228,6 +228,7 @@ def test_numpy_pixel_types() -> None:
 
 
 def test_update_unset(pixels: model.Pixels) -> None:
+    """Make sure objects appended to mutable sequences are included in the xml."""
     ome = model.OME()
     pixels.channels.extend([model.Channel(), model.Channel()])
     img = model.Image(pixels=pixels)
@@ -236,7 +237,7 @@ def test_update_unset(pixels: model.Pixels) -> None:
     ome.images.append(img)
     ome.structured_annotations.append(model.CommentAnnotation(value="test"))
 
-    xml = ome.to_xml()
+    xml = ome.to_xml(exclude_unset=True)
     assert "Pixels" in xml
     assert "Channel" in xml
     assert "Image" in xml

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -225,3 +225,21 @@ def test_numpy_pixel_types() -> None:
 
     for m in model.PixelType:
         numpy.dtype(m.numpy_dtype)
+
+
+def test_update_unset(pixels: model.Pixels) -> None:
+    ome = model.OME()
+    pixels.channels.extend([model.Channel(), model.Channel()])
+    img = model.Image(pixels=pixels)
+    ome.projects.append(model.Project())
+    ome.datasets.append(model.Dataset())
+    ome.images.append(img)
+    ome.structured_annotations.append(model.CommentAnnotation(value="test"))
+
+    xml = ome.to_xml()
+    assert "Pixels" in xml
+    assert "Channel" in xml
+    assert "Image" in xml
+    assert "CommentAnnotation" in xml
+
+    assert from_xml(xml) == ome

--- a/tests/test_omero_cli.py
+++ b/tests/test_omero_cli.py
@@ -75,8 +75,8 @@ def conn() -> BlitzGateway:
     "datatype, id",
     [
         ("Dataset", 21157),
-        # ("Project", 5414),
-        # ("Image", 1110952),
+        ("Project", 5414),
+        ("Image", 1110952),
     ],
 )
 @pytest.mark.filterwarnings("ignore::DeprecationWarning")

--- a/tests/test_omero_cli.py
+++ b/tests/test_omero_cli.py
@@ -80,7 +80,6 @@ def conn() -> BlitzGateway:
     ],
 )
 @pytest.mark.filterwarnings("ignore::DeprecationWarning")
-@pytest.mark.filterwarnings("ignore:Reference to unknown ID:")
 def test_populate_xml(
     data_dir: Path,
     datatype: str,

--- a/tests/test_omero_cli.py
+++ b/tests/test_omero_cli.py
@@ -73,9 +73,14 @@ def conn() -> BlitzGateway:
 @pytest.mark.skipif("OMERO_USER" not in os.environ, reason="OMERO_USER not set")
 @pytest.mark.parametrize(
     "datatype, id",
-    [("Dataset", 21157), ("Project", 5414), ("Image", 1110952)],
+    [
+        ("Dataset", 21157),
+        # ("Project", 5414),
+        # ("Image", 1110952),
+    ],
 )
 @pytest.mark.filterwarnings("ignore::DeprecationWarning")
+@pytest.mark.filterwarnings("ignore:Reference to unknown ID:")
 def test_populate_xml(
     data_dir: Path,
     datatype: str,
@@ -96,4 +101,5 @@ def test_populate_xml(
     )
     assert isinstance(ome, OME)
     assert dest.exists()
-    assert isinstance(OME.from_xml(str(dest)), OME)
+    ome2 = OME.from_xml(dest)
+    assert ome2 == ome


### PR DESCRIPTION
this solves the issue mentioned in https://forum.image.sc/t/ome-types-rewritten-requesting-alpha-testers/83174/28
where pydantic wasn't able to determine that a value had been "set" if it's a mutation of an existing sequence (e.g. `structured_annotations.append()`, leading to missing values in the xml output when `exclude_unset=True`