### PR TITLE
feat: add transformations to from_xml

### DIFF
--- a/src/ome_types/etree_fixes.py
+++ b/src/ome_types/etree_fixes.py
@@ -11,11 +11,16 @@ if TYPE_CHECKING:
 NSMAP = {"": OME_2016_06_URI, "ome": OME_2016_06_URI}
 
 
+# See note before using...
 def fix_micro_manager_instrument(tree: AnyElementTree) -> AnyElementTree:
     """Fix MicroManager Instrument and Detector IDs and References.
 
     Some versions of OME-XML produced by MicroManager have invalid IDs (and references)
     for Instruments and Detectors. This function fixes those IDs and references.
+
+    NOTE: as of v0.4.0, bad IDs and references are caught during ID validation anyway,
+    so this is mostly an example of a fix function, and could be used to prevent
+    the warning from being raised.
     """
     for i_idx, instrument in enumerate(tree.findall("Instrument", NSMAP)):
         old_id = instrument.get("ID")
@@ -37,3 +42,4 @@ def fix_micro_manager_instrument(tree: AnyElementTree) -> AnyElementTree:
 
 
 ALL_FIXES = [fix_micro_manager_instrument]
+__all__ = ["ALL_FIXES", "fix_micro_manager_instrument"]

--- a/src/ome_types/fixes.py
+++ b/src/ome_types/fixes.py
@@ -12,7 +12,11 @@ NSMAP = {"": OME_2016_06_URI, "ome": OME_2016_06_URI}
 
 
 def fix_micro_manager_instrument(tree: AnyElementTree) -> AnyElementTree:
-    """Fix MicroManager Instrument and Detector IDs and References."""
+    """Fix MicroManager Instrument and Detector IDs and References.
+
+    Some versions of OME-XML produced by MicroManager have invalid IDs (and references)
+    for Instruments and Detectors. This function fixes those IDs and references.
+    """
     for i_idx, instrument in enumerate(tree.findall("Instrument", NSMAP)):
         old_id = instrument.get("ID")
         if old_id.startswith("Microscope"):

--- a/src/ome_types/fixes.py
+++ b/src/ome_types/fixes.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from ome_types._conversion import OME_2016_06_URI
+
+if TYPE_CHECKING:
+    from ome_types._conversion import AnyElementTree
+
+
+NSMAP = {"": OME_2016_06_URI, "ome": OME_2016_06_URI}
+
+
+def fix_micro_manager_instrument(tree: AnyElementTree) -> AnyElementTree:
+    """Fix MicroManager Instrument and Detector IDs and References."""
+    for i_idx, instrument in enumerate(tree.findall("Instrument", NSMAP)):
+        old_id = instrument.get("ID")
+        if old_id.startswith("Microscope"):
+            new_id = f"Instrument:{i_idx}"
+            instrument.set("ID", new_id)
+            for ref in tree.findall(f".//InstrumentRef[@ID='{old_id}']", NSMAP):
+                ref.set("ID", new_id)
+
+        for d_idx, detector in enumerate(instrument.findall(".//Detector", NSMAP)):
+            old_id = detector.get("ID")
+            if not old_id.startswith("Detector:"):
+                new_id = f"Detector:{old_id if old_id.isdigit() else d_idx}"
+                detector.set("ID", new_id)
+                for ref in tree.findall(f".//DetectorSettings[@ID='{old_id}']", NSMAP):
+                    ref.set("ID", new_id)
+
+    return tree
+
+
+ALL_FIXES = [fix_micro_manager_instrument]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,7 +14,11 @@ if TYPE_CHECKING:
 
 DATA = Path(__file__).parent / "data"
 ALL_XML = set(DATA.glob("*.ome.xml"))
-INVALID = {DATA / "invalid_xml_annotation.ome.xml", DATA / "bad.ome.xml"}
+INVALID = {
+    DATA / "invalid_xml_annotation.ome.xml",
+    DATA / "bad.ome.xml",
+    DATA / "MMStack.ome.xml",
+}
 OLD_SCHEMA = {DATA / "seq0000xy01c1.ome.xml", DATA / "2008_instrument.ome.xml"}
 WITH_XML_ANNOTATIONS = {
     DATA / "ome_ns.ome.xml",

--- a/tests/data/MMStack.ome.xml
+++ b/tests/data/MMStack.ome.xml
@@ -1,0 +1,410 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<OME xmlns="http://www.openmicroscopy.org/Schemas/OME/2016-06"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.openmicroscopy.org/Schemas/OME/2016-06 http://www.openmicroscopy.org/Schemas/OME/2016-06/ome.xsd">
+    <Instrument ID="Microscope">
+        <Detector ID="Camera" Manufacturer="DCam" Model="DemoCamera-MultiMode" Offset="0.0"
+            SerialNumber="V1.0" />
+    </Instrument>
+    <Image ID="Image:0" Name="image_stack_tpzc_50tp_2p_5z_3c_512k_1_MMStack_2-Pos000_000">
+        <Description />
+        <InstrumentRef ID="Microscope" />
+        <StageLabel Name="2-Pos000_000" X="-256.0" XUnit="µm" Y="-256.0" YUnit="µm" />
+        <Pixels BigEndian="false" DimensionOrder="XYCZT" ID="Pixels:0" PhysicalSizeX="2.0"
+            PhysicalSizeXUnit="µm" PhysicalSizeY="2.0" PhysicalSizeYUnit="µm" PhysicalSizeZ="1.75"
+            PhysicalSizeZUnit="µm" SizeC="3" SizeT="2" SizeX="256" SizeY="256" SizeZ="5"
+            TimeIncrement="1.0" TimeIncrementUnit="ms" Type="uint16">
+            <Channel ID="Channel:0:0" Name="Cy5" SamplesPerPixel="1">
+                <DetectorSettings Binning="2x2" Gain="1.0" ID="Camera" Integration="20"
+                    Offset="1.0" ReadOutRate="1.0" ReadOutRateUnit="Hz" Voltage="1.0"
+                    VoltageUnit="V" Zoom="3.0" />
+                <LightPath />
+            </Channel>
+            <Channel ID="Channel:0:1" Name="DAPI" SamplesPerPixel="1">
+                <LightPath />
+            </Channel>
+            <Channel ID="Channel:0:2" Name="FITC" SamplesPerPixel="1">
+                <LightPath />
+            </Channel>
+            <TiffData FirstC="0" FirstT="0" FirstZ="0" IFD="0" PlaneCount="1">
+                <UUID FileName="image_stack_tpzc_50tp_2p_5z_3c_512k_1_MMStack_2-Pos000_000.ome.tif">urn:uuid:659dc8f0-3839-4594-bd3e-41625b4736ef</UUID>
+            </TiffData>
+            <TiffData FirstC="1" FirstT="0" FirstZ="0" IFD="1" PlaneCount="1">
+                <UUID FileName="image_stack_tpzc_50tp_2p_5z_3c_512k_1_MMStack_2-Pos000_000.ome.tif">urn:uuid:659dc8f0-3839-4594-bd3e-41625b4736ef</UUID>
+            </TiffData>
+            <TiffData FirstC="2" FirstT="0" FirstZ="0" IFD="2" PlaneCount="1">
+                <UUID FileName="image_stack_tpzc_50tp_2p_5z_3c_512k_1_MMStack_2-Pos000_000.ome.tif">urn:uuid:659dc8f0-3839-4594-bd3e-41625b4736ef</UUID>
+            </TiffData>
+            <TiffData FirstC="0" FirstT="0" FirstZ="1" IFD="3" PlaneCount="1">
+                <UUID FileName="image_stack_tpzc_50tp_2p_5z_3c_512k_1_MMStack_2-Pos000_000.ome.tif">urn:uuid:659dc8f0-3839-4594-bd3e-41625b4736ef</UUID>
+            </TiffData>
+            <TiffData FirstC="1" FirstT="0" FirstZ="1" IFD="4" PlaneCount="1">
+                <UUID FileName="image_stack_tpzc_50tp_2p_5z_3c_512k_1_MMStack_2-Pos000_000.ome.tif">urn:uuid:659dc8f0-3839-4594-bd3e-41625b4736ef</UUID>
+            </TiffData>
+            <TiffData FirstC="2" FirstT="0" FirstZ="1" IFD="5" PlaneCount="1">
+                <UUID FileName="image_stack_tpzc_50tp_2p_5z_3c_512k_1_MMStack_2-Pos000_000.ome.tif">urn:uuid:659dc8f0-3839-4594-bd3e-41625b4736ef</UUID>
+            </TiffData>
+            <TiffData FirstC="0" FirstT="0" FirstZ="2" IFD="6" PlaneCount="1">
+                <UUID FileName="image_stack_tpzc_50tp_2p_5z_3c_512k_1_MMStack_2-Pos000_000.ome.tif">urn:uuid:659dc8f0-3839-4594-bd3e-41625b4736ef</UUID>
+            </TiffData>
+            <TiffData FirstC="1" FirstT="0" FirstZ="2" IFD="7" PlaneCount="1">
+                <UUID FileName="image_stack_tpzc_50tp_2p_5z_3c_512k_1_MMStack_2-Pos000_000.ome.tif">urn:uuid:659dc8f0-3839-4594-bd3e-41625b4736ef</UUID>
+            </TiffData>
+            <TiffData FirstC="2" FirstT="0" FirstZ="2" IFD="8" PlaneCount="1">
+                <UUID FileName="image_stack_tpzc_50tp_2p_5z_3c_512k_1_MMStack_2-Pos000_000.ome.tif">urn:uuid:659dc8f0-3839-4594-bd3e-41625b4736ef</UUID>
+            </TiffData>
+            <TiffData FirstC="0" FirstT="0" FirstZ="3" IFD="9" PlaneCount="1">
+                <UUID FileName="image_stack_tpzc_50tp_2p_5z_3c_512k_1_MMStack_2-Pos000_000.ome.tif">urn:uuid:659dc8f0-3839-4594-bd3e-41625b4736ef</UUID>
+            </TiffData>
+            <TiffData FirstC="1" FirstT="0" FirstZ="3" IFD="10" PlaneCount="1">
+                <UUID FileName="image_stack_tpzc_50tp_2p_5z_3c_512k_1_MMStack_2-Pos000_000.ome.tif">urn:uuid:659dc8f0-3839-4594-bd3e-41625b4736ef</UUID>
+            </TiffData>
+            <TiffData FirstC="2" FirstT="0" FirstZ="3" IFD="11" PlaneCount="1">
+                <UUID FileName="image_stack_tpzc_50tp_2p_5z_3c_512k_1_MMStack_2-Pos000_000.ome.tif">urn:uuid:659dc8f0-3839-4594-bd3e-41625b4736ef</UUID>
+            </TiffData>
+            <TiffData FirstC="0" FirstT="0" FirstZ="4" IFD="12" PlaneCount="1">
+                <UUID FileName="image_stack_tpzc_50tp_2p_5z_3c_512k_1_MMStack_2-Pos000_000.ome.tif">urn:uuid:659dc8f0-3839-4594-bd3e-41625b4736ef</UUID>
+            </TiffData>
+            <TiffData FirstC="1" FirstT="0" FirstZ="4" IFD="13" PlaneCount="1">
+                <UUID FileName="image_stack_tpzc_50tp_2p_5z_3c_512k_1_MMStack_2-Pos000_000.ome.tif">urn:uuid:659dc8f0-3839-4594-bd3e-41625b4736ef</UUID>
+            </TiffData>
+            <TiffData FirstC="2" FirstT="0" FirstZ="4" IFD="14" PlaneCount="1">
+                <UUID FileName="image_stack_tpzc_50tp_2p_5z_3c_512k_1_MMStack_2-Pos000_000.ome.tif">urn:uuid:659dc8f0-3839-4594-bd3e-41625b4736ef</UUID>
+            </TiffData>
+            <TiffData FirstC="0" FirstT="1" FirstZ="0" IFD="15" PlaneCount="1">
+                <UUID FileName="image_stack_tpzc_50tp_2p_5z_3c_512k_1_MMStack_2-Pos000_000.ome.tif">urn:uuid:659dc8f0-3839-4594-bd3e-41625b4736ef</UUID>
+            </TiffData>
+            <TiffData FirstC="1" FirstT="1" FirstZ="0" IFD="16" PlaneCount="1">
+                <UUID FileName="image_stack_tpzc_50tp_2p_5z_3c_512k_1_MMStack_2-Pos000_000.ome.tif">urn:uuid:659dc8f0-3839-4594-bd3e-41625b4736ef</UUID>
+            </TiffData>
+            <TiffData FirstC="2" FirstT="1" FirstZ="0" IFD="17" PlaneCount="1">
+                <UUID FileName="image_stack_tpzc_50tp_2p_5z_3c_512k_1_MMStack_2-Pos000_000.ome.tif">urn:uuid:659dc8f0-3839-4594-bd3e-41625b4736ef</UUID>
+            </TiffData>
+            <TiffData FirstC="0" FirstT="1" FirstZ="1" IFD="18" PlaneCount="1">
+                <UUID FileName="image_stack_tpzc_50tp_2p_5z_3c_512k_1_MMStack_2-Pos000_000.ome.tif">urn:uuid:659dc8f0-3839-4594-bd3e-41625b4736ef</UUID>
+            </TiffData>
+            <TiffData FirstC="1" FirstT="1" FirstZ="1" IFD="19" PlaneCount="1">
+                <UUID FileName="image_stack_tpzc_50tp_2p_5z_3c_512k_1_MMStack_2-Pos000_000.ome.tif">urn:uuid:659dc8f0-3839-4594-bd3e-41625b4736ef</UUID>
+            </TiffData>
+            <TiffData FirstC="2" FirstT="1" FirstZ="1" IFD="20" PlaneCount="1">
+                <UUID FileName="image_stack_tpzc_50tp_2p_5z_3c_512k_1_MMStack_2-Pos000_000.ome.tif">urn:uuid:659dc8f0-3839-4594-bd3e-41625b4736ef</UUID>
+            </TiffData>
+            <TiffData FirstC="0" FirstT="1" FirstZ="2" IFD="21" PlaneCount="1">
+                <UUID FileName="image_stack_tpzc_50tp_2p_5z_3c_512k_1_MMStack_2-Pos000_000.ome.tif">urn:uuid:659dc8f0-3839-4594-bd3e-41625b4736ef</UUID>
+            </TiffData>
+            <TiffData FirstC="1" FirstT="1" FirstZ="2" IFD="22" PlaneCount="1">
+                <UUID FileName="image_stack_tpzc_50tp_2p_5z_3c_512k_1_MMStack_2-Pos000_000.ome.tif">urn:uuid:659dc8f0-3839-4594-bd3e-41625b4736ef</UUID>
+            </TiffData>
+            <TiffData FirstC="2" FirstT="1" FirstZ="2" IFD="23" PlaneCount="1">
+                <UUID FileName="image_stack_tpzc_50tp_2p_5z_3c_512k_1_MMStack_2-Pos000_000.ome.tif">urn:uuid:659dc8f0-3839-4594-bd3e-41625b4736ef</UUID>
+            </TiffData>
+            <TiffData FirstC="0" FirstT="1" FirstZ="3" IFD="24" PlaneCount="1">
+                <UUID FileName="image_stack_tpzc_50tp_2p_5z_3c_512k_1_MMStack_2-Pos000_000.ome.tif">urn:uuid:659dc8f0-3839-4594-bd3e-41625b4736ef</UUID>
+            </TiffData>
+            <TiffData FirstC="1" FirstT="1" FirstZ="3" IFD="25" PlaneCount="1">
+                <UUID FileName="image_stack_tpzc_50tp_2p_5z_3c_512k_1_MMStack_2-Pos000_000.ome.tif">urn:uuid:659dc8f0-3839-4594-bd3e-41625b4736ef</UUID>
+            </TiffData>
+            <TiffData FirstC="2" FirstT="1" FirstZ="3" IFD="26" PlaneCount="1">
+                <UUID FileName="image_stack_tpzc_50tp_2p_5z_3c_512k_1_MMStack_2-Pos000_000.ome.tif">urn:uuid:659dc8f0-3839-4594-bd3e-41625b4736ef</UUID>
+            </TiffData>
+            <TiffData FirstC="0" FirstT="1" FirstZ="4" IFD="27" PlaneCount="1">
+                <UUID FileName="image_stack_tpzc_50tp_2p_5z_3c_512k_1_MMStack_2-Pos000_000.ome.tif">urn:uuid:659dc8f0-3839-4594-bd3e-41625b4736ef</UUID>
+            </TiffData>
+            <TiffData FirstC="1" FirstT="1" FirstZ="4" IFD="28" PlaneCount="1">
+                <UUID FileName="image_stack_tpzc_50tp_2p_5z_3c_512k_1_MMStack_2-Pos000_000.ome.tif">urn:uuid:659dc8f0-3839-4594-bd3e-41625b4736ef</UUID>
+            </TiffData>
+            <TiffData FirstC="2" FirstT="1" FirstZ="4" IFD="29" PlaneCount="1">
+                <UUID FileName="image_stack_tpzc_50tp_2p_5z_3c_512k_1_MMStack_2-Pos000_000.ome.tif">urn:uuid:659dc8f0-3839-4594-bd3e-41625b4736ef</UUID>
+            </TiffData>
+            <Plane DeltaT="117.0" DeltaTUnit="ms" ExposureTime="1.0" ExposureTimeUnit="ms"
+                PositionX="-256.0" PositionXUnit="µm" PositionY="-256.0" PositionYUnit="µm"
+                PositionZ="-4.0" PositionZUnit="µm" TheC="0" TheT="0" TheZ="0" />
+            <Plane DeltaT="172.0" DeltaTUnit="ms" ExposureTime="1.0" ExposureTimeUnit="ms"
+                PositionX="-256.0" PositionXUnit="µm" PositionY="-256.0" PositionYUnit="µm"
+                PositionZ="-4.0" PositionZUnit="µm" TheC="1" TheT="0" TheZ="0" />
+            <Plane DeltaT="220.0" DeltaTUnit="ms" ExposureTime="1.0" ExposureTimeUnit="ms"
+                PositionX="-256.0" PositionXUnit="µm" PositionY="-256.0" PositionYUnit="µm"
+                PositionZ="-4.0" PositionZUnit="µm" TheC="2" TheT="0" TheZ="0" />
+            <Plane DeltaT="279.0" DeltaTUnit="ms" ExposureTime="1.0" ExposureTimeUnit="ms"
+                PositionX="-256.0" PositionXUnit="µm" PositionY="-256.0" PositionYUnit="µm"
+                PositionZ="-2.25" PositionZUnit="µm" TheC="0" TheT="0" TheZ="1" />
+            <Plane DeltaT="321.0" DeltaTUnit="ms" ExposureTime="1.0" ExposureTimeUnit="ms"
+                PositionX="-256.0" PositionXUnit="µm" PositionY="-256.0" PositionYUnit="µm"
+                PositionZ="-2.25" PositionZUnit="µm" TheC="1" TheT="0" TheZ="1" />
+            <Plane DeltaT="371.0" DeltaTUnit="ms" ExposureTime="1.0" ExposureTimeUnit="ms"
+                PositionX="-256.0" PositionXUnit="µm" PositionY="-256.0" PositionYUnit="µm"
+                PositionZ="-2.25" PositionZUnit="µm" TheC="2" TheT="0" TheZ="1" />
+            <Plane DeltaT="418.0" DeltaTUnit="ms" ExposureTime="1.0" ExposureTimeUnit="ms"
+                PositionX="-256.0" PositionXUnit="µm" PositionY="-256.0" PositionYUnit="µm"
+                PositionZ="-0.5" PositionZUnit="µm" TheC="0" TheT="0" TheZ="2" />
+            <Plane DeltaT="452.0" DeltaTUnit="ms" ExposureTime="1.0" ExposureTimeUnit="ms"
+                PositionX="-256.0" PositionXUnit="µm" PositionY="-256.0" PositionYUnit="µm"
+                PositionZ="-0.5" PositionZUnit="µm" TheC="1" TheT="0" TheZ="2" />
+            <Plane DeltaT="484.0" DeltaTUnit="ms" ExposureTime="1.0" ExposureTimeUnit="ms"
+                PositionX="-256.0" PositionXUnit="µm" PositionY="-256.0" PositionYUnit="µm"
+                PositionZ="-0.5" PositionZUnit="µm" TheC="2" TheT="0" TheZ="2" />
+            <Plane DeltaT="515.0" DeltaTUnit="ms" ExposureTime="1.0" ExposureTimeUnit="ms"
+                PositionX="-256.0" PositionXUnit="µm" PositionY="-256.0" PositionYUnit="µm"
+                PositionZ="1.25" PositionZUnit="µm" TheC="0" TheT="0" TheZ="3" />
+            <Plane DeltaT="545.0" DeltaTUnit="ms" ExposureTime="1.0" ExposureTimeUnit="ms"
+                PositionX="-256.0" PositionXUnit="µm" PositionY="-256.0" PositionYUnit="µm"
+                PositionZ="1.25" PositionZUnit="µm" TheC="1" TheT="0" TheZ="3" />
+            <Plane DeltaT="581.0" DeltaTUnit="ms" ExposureTime="1.0" ExposureTimeUnit="ms"
+                PositionX="-256.0" PositionXUnit="µm" PositionY="-256.0" PositionYUnit="µm"
+                PositionZ="1.25" PositionZUnit="µm" TheC="2" TheT="0" TheZ="3" />
+            <Plane DeltaT="617.0" DeltaTUnit="ms" ExposureTime="1.0" ExposureTimeUnit="ms"
+                PositionX="-256.0" PositionXUnit="µm" PositionY="-256.0" PositionYUnit="µm"
+                PositionZ="3.0" PositionZUnit="µm" TheC="0" TheT="0" TheZ="4" />
+            <Plane DeltaT="650.0" DeltaTUnit="ms" ExposureTime="1.0" ExposureTimeUnit="ms"
+                PositionX="-256.0" PositionXUnit="µm" PositionY="-256.0" PositionYUnit="µm"
+                PositionZ="3.0" PositionZUnit="µm" TheC="1" TheT="0" TheZ="4" />
+            <Plane DeltaT="684.0" DeltaTUnit="ms" ExposureTime="1.0" ExposureTimeUnit="ms"
+                PositionX="-256.0" PositionXUnit="µm" PositionY="-256.0" PositionYUnit="µm"
+                PositionZ="3.0" PositionZUnit="µm" TheC="2" TheT="0" TheZ="4" />
+            <Plane DeltaT="1341.0" DeltaTUnit="ms" ExposureTime="1.0" ExposureTimeUnit="ms"
+                PositionX="-256.0" PositionXUnit="µm" PositionY="-256.0" PositionYUnit="µm"
+                PositionZ="-4.0" PositionZUnit="µm" TheC="0" TheT="1" TheZ="0" />
+            <Plane DeltaT="1379.0" DeltaTUnit="ms" ExposureTime="1.0" ExposureTimeUnit="ms"
+                PositionX="-256.0" PositionXUnit="µm" PositionY="-256.0" PositionYUnit="µm"
+                PositionZ="-4.0" PositionZUnit="µm" TheC="1" TheT="1" TheZ="0" />
+            <Plane DeltaT="1411.0" DeltaTUnit="ms" ExposureTime="1.0" ExposureTimeUnit="ms"
+                PositionX="-256.0" PositionXUnit="µm" PositionY="-256.0" PositionYUnit="µm"
+                PositionZ="-4.0" PositionZUnit="µm" TheC="2" TheT="1" TheZ="0" />
+            <Plane DeltaT="1443.0" DeltaTUnit="ms" ExposureTime="1.0" ExposureTimeUnit="ms"
+                PositionX="-256.0" PositionXUnit="µm" PositionY="-256.0" PositionYUnit="µm"
+                PositionZ="-2.25" PositionZUnit="µm" TheC="0" TheT="1" TheZ="1" />
+            <Plane DeltaT="1473.0" DeltaTUnit="ms" ExposureTime="1.0" ExposureTimeUnit="ms"
+                PositionX="-256.0" PositionXUnit="µm" PositionY="-256.0" PositionYUnit="µm"
+                PositionZ="-2.25" PositionZUnit="µm" TheC="1" TheT="1" TheZ="1" />
+            <Plane DeltaT="1507.0" DeltaTUnit="ms" ExposureTime="1.0" ExposureTimeUnit="ms"
+                PositionX="-256.0" PositionXUnit="µm" PositionY="-256.0" PositionYUnit="µm"
+                PositionZ="-2.25" PositionZUnit="µm" TheC="2" TheT="1" TheZ="1" />
+            <Plane DeltaT="1540.0" DeltaTUnit="ms" ExposureTime="1.0" ExposureTimeUnit="ms"
+                PositionX="-256.0" PositionXUnit="µm" PositionY="-256.0" PositionYUnit="µm"
+                PositionZ="-0.5" PositionZUnit="µm" TheC="0" TheT="1" TheZ="2" />
+            <Plane DeltaT="1569.0" DeltaTUnit="ms" ExposureTime="1.0" ExposureTimeUnit="ms"
+                PositionX="-256.0" PositionXUnit="µm" PositionY="-256.0" PositionYUnit="µm"
+                PositionZ="-0.5" PositionZUnit="µm" TheC="1" TheT="1" TheZ="2" />
+            <Plane DeltaT="1600.0" DeltaTUnit="ms" ExposureTime="1.0" ExposureTimeUnit="ms"
+                PositionX="-256.0" PositionXUnit="µm" PositionY="-256.0" PositionYUnit="µm"
+                PositionZ="-0.5" PositionZUnit="µm" TheC="2" TheT="1" TheZ="2" />
+            <Plane DeltaT="1631.0" DeltaTUnit="ms" ExposureTime="1.0" ExposureTimeUnit="ms"
+                PositionX="-256.0" PositionXUnit="µm" PositionY="-256.0" PositionYUnit="µm"
+                PositionZ="1.25" PositionZUnit="µm" TheC="0" TheT="1" TheZ="3" />
+            <Plane DeltaT="1657.0" DeltaTUnit="ms" ExposureTime="1.0" ExposureTimeUnit="ms"
+                PositionX="-256.0" PositionXUnit="µm" PositionY="-256.0" PositionYUnit="µm"
+                PositionZ="1.25" PositionZUnit="µm" TheC="1" TheT="1" TheZ="3" />
+            <Plane DeltaT="1690.0" DeltaTUnit="ms" ExposureTime="1.0" ExposureTimeUnit="ms"
+                PositionX="-256.0" PositionXUnit="µm" PositionY="-256.0" PositionYUnit="µm"
+                PositionZ="1.25" PositionZUnit="µm" TheC="2" TheT="1" TheZ="3" />
+            <Plane DeltaT="1724.0" DeltaTUnit="ms" ExposureTime="1.0" ExposureTimeUnit="ms"
+                PositionX="-256.0" PositionXUnit="µm" PositionY="-256.0" PositionYUnit="µm"
+                PositionZ="3.0" PositionZUnit="µm" TheC="0" TheT="1" TheZ="4" />
+            <Plane DeltaT="1753.0" DeltaTUnit="ms" ExposureTime="1.0" ExposureTimeUnit="ms"
+                PositionX="-256.0" PositionXUnit="µm" PositionY="-256.0" PositionYUnit="µm"
+                PositionZ="3.0" PositionZUnit="µm" TheC="1" TheT="1" TheZ="4" />
+            <Plane DeltaT="1783.0" DeltaTUnit="ms" ExposureTime="1.0" ExposureTimeUnit="ms"
+                PositionX="-256.0" PositionXUnit="µm" PositionY="-256.0" PositionYUnit="µm"
+                PositionZ="3.0" PositionZUnit="µm" TheC="2" TheT="1" TheZ="4" />
+        </Pixels>
+    </Image>
+    <Image ID="Image:1" Name="image_stack_tpzc_50tp_2p_5z_3c_512k_1_MMStack_2-Pos001_000">
+        <Description />
+        <InstrumentRef ID="Microscope" />
+        <StageLabel Name="2-Pos001_000" X="256.0" XUnit="µm" Y="-256.0" YUnit="µm" />
+        <Pixels BigEndian="false" DimensionOrder="XYCZT" ID="Pixels:1" PhysicalSizeX="2.0"
+            PhysicalSizeXUnit="µm" PhysicalSizeY="2.0" PhysicalSizeYUnit="µm" PhysicalSizeZ="1.75"
+            PhysicalSizeZUnit="µm" SizeC="3" SizeT="2" SizeX="256" SizeY="256" SizeZ="5"
+            TimeIncrement="1.0" TimeIncrementUnit="ms" Type="uint16">
+            <Channel ID="Channel:1:0" Name="Cy5" SamplesPerPixel="1">
+                <LightPath />
+            </Channel>
+            <Channel ID="Channel:1:1" Name="DAPI" SamplesPerPixel="1">
+                <LightPath />
+            </Channel>
+            <Channel ID="Channel:1:2" Name="FITC" SamplesPerPixel="1">
+                <LightPath />
+            </Channel>
+            <TiffData FirstC="0" FirstT="0" FirstZ="0" IFD="0" PlaneCount="1">
+                <UUID FileName="image_stack_tpzc_50tp_2p_5z_3c_512k_1_MMStack_2-Pos001_000.ome.tif">urn:uuid:a10f1945-00d9-456f-89a5-fe3a9959c369</UUID>
+            </TiffData>
+            <TiffData FirstC="1" FirstT="0" FirstZ="0" IFD="1" PlaneCount="1">
+                <UUID FileName="image_stack_tpzc_50tp_2p_5z_3c_512k_1_MMStack_2-Pos001_000.ome.tif">urn:uuid:a10f1945-00d9-456f-89a5-fe3a9959c369</UUID>
+            </TiffData>
+            <TiffData FirstC="2" FirstT="0" FirstZ="0" IFD="2" PlaneCount="1">
+                <UUID FileName="image_stack_tpzc_50tp_2p_5z_3c_512k_1_MMStack_2-Pos001_000.ome.tif">urn:uuid:a10f1945-00d9-456f-89a5-fe3a9959c369</UUID>
+            </TiffData>
+            <TiffData FirstC="0" FirstT="0" FirstZ="1" IFD="3" PlaneCount="1">
+                <UUID FileName="image_stack_tpzc_50tp_2p_5z_3c_512k_1_MMStack_2-Pos001_000.ome.tif">urn:uuid:a10f1945-00d9-456f-89a5-fe3a9959c369</UUID>
+            </TiffData>
+            <TiffData FirstC="1" FirstT="0" FirstZ="1" IFD="4" PlaneCount="1">
+                <UUID FileName="image_stack_tpzc_50tp_2p_5z_3c_512k_1_MMStack_2-Pos001_000.ome.tif">urn:uuid:a10f1945-00d9-456f-89a5-fe3a9959c369</UUID>
+            </TiffData>
+            <TiffData FirstC="2" FirstT="0" FirstZ="1" IFD="5" PlaneCount="1">
+                <UUID FileName="image_stack_tpzc_50tp_2p_5z_3c_512k_1_MMStack_2-Pos001_000.ome.tif">urn:uuid:a10f1945-00d9-456f-89a5-fe3a9959c369</UUID>
+            </TiffData>
+            <TiffData FirstC="0" FirstT="0" FirstZ="2" IFD="6" PlaneCount="1">
+                <UUID FileName="image_stack_tpzc_50tp_2p_5z_3c_512k_1_MMStack_2-Pos001_000.ome.tif">urn:uuid:a10f1945-00d9-456f-89a5-fe3a9959c369</UUID>
+            </TiffData>
+            <TiffData FirstC="1" FirstT="0" FirstZ="2" IFD="7" PlaneCount="1">
+                <UUID FileName="image_stack_tpzc_50tp_2p_5z_3c_512k_1_MMStack_2-Pos001_000.ome.tif">urn:uuid:a10f1945-00d9-456f-89a5-fe3a9959c369</UUID>
+            </TiffData>
+            <TiffData FirstC="2" FirstT="0" FirstZ="2" IFD="8" PlaneCount="1">
+                <UUID FileName="image_stack_tpzc_50tp_2p_5z_3c_512k_1_MMStack_2-Pos001_000.ome.tif">urn:uuid:a10f1945-00d9-456f-89a5-fe3a9959c369</UUID>
+            </TiffData>
+            <TiffData FirstC="0" FirstT="0" FirstZ="3" IFD="9" PlaneCount="1">
+                <UUID FileName="image_stack_tpzc_50tp_2p_5z_3c_512k_1_MMStack_2-Pos001_000.ome.tif">urn:uuid:a10f1945-00d9-456f-89a5-fe3a9959c369</UUID>
+            </TiffData>
+            <TiffData FirstC="1" FirstT="0" FirstZ="3" IFD="10" PlaneCount="1">
+                <UUID FileName="image_stack_tpzc_50tp_2p_5z_3c_512k_1_MMStack_2-Pos001_000.ome.tif">urn:uuid:a10f1945-00d9-456f-89a5-fe3a9959c369</UUID>
+            </TiffData>
+            <TiffData FirstC="2" FirstT="0" FirstZ="3" IFD="11" PlaneCount="1">
+                <UUID FileName="image_stack_tpzc_50tp_2p_5z_3c_512k_1_MMStack_2-Pos001_000.ome.tif">urn:uuid:a10f1945-00d9-456f-89a5-fe3a9959c369</UUID>
+            </TiffData>
+            <TiffData FirstC="0" FirstT="0" FirstZ="4" IFD="12" PlaneCount="1">
+                <UUID FileName="image_stack_tpzc_50tp_2p_5z_3c_512k_1_MMStack_2-Pos001_000.ome.tif">urn:uuid:a10f1945-00d9-456f-89a5-fe3a9959c369</UUID>
+            </TiffData>
+            <TiffData FirstC="1" FirstT="0" FirstZ="4" IFD="13" PlaneCount="1">
+                <UUID FileName="image_stack_tpzc_50tp_2p_5z_3c_512k_1_MMStack_2-Pos001_000.ome.tif">urn:uuid:a10f1945-00d9-456f-89a5-fe3a9959c369</UUID>
+            </TiffData>
+            <TiffData FirstC="2" FirstT="0" FirstZ="4" IFD="14" PlaneCount="1">
+                <UUID FileName="image_stack_tpzc_50tp_2p_5z_3c_512k_1_MMStack_2-Pos001_000.ome.tif">urn:uuid:a10f1945-00d9-456f-89a5-fe3a9959c369</UUID>
+            </TiffData>
+            <TiffData FirstC="0" FirstT="1" FirstZ="0" IFD="15" PlaneCount="1">
+                <UUID FileName="image_stack_tpzc_50tp_2p_5z_3c_512k_1_MMStack_2-Pos001_000.ome.tif">urn:uuid:a10f1945-00d9-456f-89a5-fe3a9959c369</UUID>
+            </TiffData>
+            <TiffData FirstC="1" FirstT="1" FirstZ="0" IFD="16" PlaneCount="1">
+                <UUID FileName="image_stack_tpzc_50tp_2p_5z_3c_512k_1_MMStack_2-Pos001_000.ome.tif">urn:uuid:a10f1945-00d9-456f-89a5-fe3a9959c369</UUID>
+            </TiffData>
+            <TiffData FirstC="2" FirstT="1" FirstZ="0" IFD="17" PlaneCount="1">
+                <UUID FileName="image_stack_tpzc_50tp_2p_5z_3c_512k_1_MMStack_2-Pos001_000.ome.tif">urn:uuid:a10f1945-00d9-456f-89a5-fe3a9959c369</UUID>
+            </TiffData>
+            <TiffData FirstC="0" FirstT="1" FirstZ="1" IFD="18" PlaneCount="1">
+                <UUID FileName="image_stack_tpzc_50tp_2p_5z_3c_512k_1_MMStack_2-Pos001_000.ome.tif">urn:uuid:a10f1945-00d9-456f-89a5-fe3a9959c369</UUID>
+            </TiffData>
+            <TiffData FirstC="1" FirstT="1" FirstZ="1" IFD="19" PlaneCount="1">
+                <UUID FileName="image_stack_tpzc_50tp_2p_5z_3c_512k_1_MMStack_2-Pos001_000.ome.tif">urn:uuid:a10f1945-00d9-456f-89a5-fe3a9959c369</UUID>
+            </TiffData>
+            <TiffData FirstC="2" FirstT="1" FirstZ="1" IFD="20" PlaneCount="1">
+                <UUID FileName="image_stack_tpzc_50tp_2p_5z_3c_512k_1_MMStack_2-Pos001_000.ome.tif">urn:uuid:a10f1945-00d9-456f-89a5-fe3a9959c369</UUID>
+            </TiffData>
+            <TiffData FirstC="0" FirstT="1" FirstZ="2" IFD="21" PlaneCount="1">
+                <UUID FileName="image_stack_tpzc_50tp_2p_5z_3c_512k_1_MMStack_2-Pos001_000.ome.tif">urn:uuid:a10f1945-00d9-456f-89a5-fe3a9959c369</UUID>
+            </TiffData>
+            <TiffData FirstC="1" FirstT="1" FirstZ="2" IFD="22" PlaneCount="1">
+                <UUID FileName="image_stack_tpzc_50tp_2p_5z_3c_512k_1_MMStack_2-Pos001_000.ome.tif">urn:uuid:a10f1945-00d9-456f-89a5-fe3a9959c369</UUID>
+            </TiffData>
+            <TiffData FirstC="2" FirstT="1" FirstZ="2" IFD="23" PlaneCount="1">
+                <UUID FileName="image_stack_tpzc_50tp_2p_5z_3c_512k_1_MMStack_2-Pos001_000.ome.tif">urn:uuid:a10f1945-00d9-456f-89a5-fe3a9959c369</UUID>
+            </TiffData>
+            <TiffData FirstC="0" FirstT="1" FirstZ="3" IFD="24" PlaneCount="1">
+                <UUID FileName="image_stack_tpzc_50tp_2p_5z_3c_512k_1_MMStack_2-Pos001_000.ome.tif">urn:uuid:a10f1945-00d9-456f-89a5-fe3a9959c369</UUID>
+            </TiffData>
+            <TiffData FirstC="1" FirstT="1" FirstZ="3" IFD="25" PlaneCount="1">
+                <UUID FileName="image_stack_tpzc_50tp_2p_5z_3c_512k_1_MMStack_2-Pos001_000.ome.tif">urn:uuid:a10f1945-00d9-456f-89a5-fe3a9959c369</UUID>
+            </TiffData>
+            <TiffData FirstC="2" FirstT="1" FirstZ="3" IFD="26" PlaneCount="1">
+                <UUID FileName="image_stack_tpzc_50tp_2p_5z_3c_512k_1_MMStack_2-Pos001_000.ome.tif">urn:uuid:a10f1945-00d9-456f-89a5-fe3a9959c369</UUID>
+            </TiffData>
+            <TiffData FirstC="0" FirstT="1" FirstZ="4" IFD="27" PlaneCount="1">
+                <UUID FileName="image_stack_tpzc_50tp_2p_5z_3c_512k_1_MMStack_2-Pos001_000.ome.tif">urn:uuid:a10f1945-00d9-456f-89a5-fe3a9959c369</UUID>
+            </TiffData>
+            <TiffData FirstC="1" FirstT="1" FirstZ="4" IFD="28" PlaneCount="1">
+                <UUID FileName="image_stack_tpzc_50tp_2p_5z_3c_512k_1_MMStack_2-Pos001_000.ome.tif">urn:uuid:a10f1945-00d9-456f-89a5-fe3a9959c369</UUID>
+            </TiffData>
+            <TiffData FirstC="2" FirstT="1" FirstZ="4" IFD="29" PlaneCount="1">
+                <UUID FileName="image_stack_tpzc_50tp_2p_5z_3c_512k_1_MMStack_2-Pos001_000.ome.tif">urn:uuid:a10f1945-00d9-456f-89a5-fe3a9959c369</UUID>
+            </TiffData>
+            <Plane DeltaT="768.0" DeltaTUnit="ms" ExposureTime="1.0" ExposureTimeUnit="ms"
+                PositionX="256.0" PositionXUnit="µm" PositionY="-256.0" PositionYUnit="µm"
+                PositionZ="-4.0" PositionZUnit="µm" TheC="0" TheT="0" TheZ="0" />
+            <Plane DeltaT="817.0" DeltaTUnit="ms" ExposureTime="1.0" ExposureTimeUnit="ms"
+                PositionX="256.0" PositionXUnit="µm" PositionY="-256.0" PositionYUnit="µm"
+                PositionZ="-4.0" PositionZUnit="µm" TheC="1" TheT="0" TheZ="0" />
+            <Plane DeltaT="852.0" DeltaTUnit="ms" ExposureTime="1.0" ExposureTimeUnit="ms"
+                PositionX="256.0" PositionXUnit="µm" PositionY="-256.0" PositionYUnit="µm"
+                PositionZ="-4.0" PositionZUnit="µm" TheC="2" TheT="0" TheZ="0" />
+            <Plane DeltaT="887.0" DeltaTUnit="ms" ExposureTime="1.0" ExposureTimeUnit="ms"
+                PositionX="256.0" PositionXUnit="µm" PositionY="-256.0" PositionYUnit="µm"
+                PositionZ="-2.25" PositionZUnit="µm" TheC="0" TheT="0" TheZ="1" />
+            <Plane DeltaT="919.0" DeltaTUnit="ms" ExposureTime="1.0" ExposureTimeUnit="ms"
+                PositionX="256.0" PositionXUnit="µm" PositionY="-256.0" PositionYUnit="µm"
+                PositionZ="-2.25" PositionZUnit="µm" TheC="1" TheT="0" TheZ="1" />
+            <Plane DeltaT="951.0" DeltaTUnit="ms" ExposureTime="1.0" ExposureTimeUnit="ms"
+                PositionX="256.0" PositionXUnit="µm" PositionY="-256.0" PositionYUnit="µm"
+                PositionZ="-2.25" PositionZUnit="µm" TheC="2" TheT="0" TheZ="1" />
+            <Plane DeltaT="985.0" DeltaTUnit="ms" ExposureTime="1.0" ExposureTimeUnit="ms"
+                PositionX="256.0" PositionXUnit="µm" PositionY="-256.0" PositionYUnit="µm"
+                PositionZ="-0.5" PositionZUnit="µm" TheC="0" TheT="0" TheZ="2" />
+            <Plane DeltaT="1016.0" DeltaTUnit="ms" ExposureTime="1.0" ExposureTimeUnit="ms"
+                PositionX="256.0" PositionXUnit="µm" PositionY="-256.0" PositionYUnit="µm"
+                PositionZ="-0.5" PositionZUnit="µm" TheC="1" TheT="0" TheZ="2" />
+            <Plane DeltaT="1049.0" DeltaTUnit="ms" ExposureTime="1.0" ExposureTimeUnit="ms"
+                PositionX="256.0" PositionXUnit="µm" PositionY="-256.0" PositionYUnit="µm"
+                PositionZ="-0.5" PositionZUnit="µm" TheC="2" TheT="0" TheZ="2" />
+            <Plane DeltaT="1082.0" DeltaTUnit="ms" ExposureTime="1.0" ExposureTimeUnit="ms"
+                PositionX="256.0" PositionXUnit="µm" PositionY="-256.0" PositionYUnit="µm"
+                PositionZ="1.25" PositionZUnit="µm" TheC="0" TheT="0" TheZ="3" />
+            <Plane DeltaT="1119.0" DeltaTUnit="ms" ExposureTime="1.0" ExposureTimeUnit="ms"
+                PositionX="256.0" PositionXUnit="µm" PositionY="-256.0" PositionYUnit="µm"
+                PositionZ="1.25" PositionZUnit="µm" TheC="1" TheT="0" TheZ="3" />
+            <Plane DeltaT="1155.0" DeltaTUnit="ms" ExposureTime="1.0" ExposureTimeUnit="ms"
+                PositionX="256.0" PositionXUnit="µm" PositionY="-256.0" PositionYUnit="µm"
+                PositionZ="1.25" PositionZUnit="µm" TheC="2" TheT="0" TheZ="3" />
+            <Plane DeltaT="1188.0" DeltaTUnit="ms" ExposureTime="1.0" ExposureTimeUnit="ms"
+                PositionX="256.0" PositionXUnit="µm" PositionY="-256.0" PositionYUnit="µm"
+                PositionZ="3.0" PositionZUnit="µm" TheC="0" TheT="0" TheZ="4" />
+            <Plane DeltaT="1223.0" DeltaTUnit="ms" ExposureTime="1.0" ExposureTimeUnit="ms"
+                PositionX="256.0" PositionXUnit="µm" PositionY="-256.0" PositionYUnit="µm"
+                PositionZ="3.0" PositionZUnit="µm" TheC="1" TheT="0" TheZ="4" />
+            <Plane DeltaT="1257.0" DeltaTUnit="ms" ExposureTime="1.0" ExposureTimeUnit="ms"
+                PositionX="256.0" PositionXUnit="µm" PositionY="-256.0" PositionYUnit="µm"
+                PositionZ="3.0" PositionZUnit="µm" TheC="2" TheT="0" TheZ="4" />
+            <Plane DeltaT="1866.0" DeltaTUnit="ms" ExposureTime="1.0" ExposureTimeUnit="ms"
+                PositionX="256.0" PositionXUnit="µm" PositionY="-256.0" PositionYUnit="µm"
+                PositionZ="-4.0" PositionZUnit="µm" TheC="0" TheT="1" TheZ="0" />
+            <Plane DeltaT="1899.0" DeltaTUnit="ms" ExposureTime="1.0" ExposureTimeUnit="ms"
+                PositionX="256.0" PositionXUnit="µm" PositionY="-256.0" PositionYUnit="µm"
+                PositionZ="-4.0" PositionZUnit="µm" TheC="1" TheT="1" TheZ="0" />
+            <Plane DeltaT="1928.0" DeltaTUnit="ms" ExposureTime="1.0" ExposureTimeUnit="ms"
+                PositionX="256.0" PositionXUnit="µm" PositionY="-256.0" PositionYUnit="µm"
+                PositionZ="-4.0" PositionZUnit="µm" TheC="2" TheT="1" TheZ="0" />
+            <Plane DeltaT="1963.0" DeltaTUnit="ms" ExposureTime="1.0" ExposureTimeUnit="ms"
+                PositionX="256.0" PositionXUnit="µm" PositionY="-256.0" PositionYUnit="µm"
+                PositionZ="-2.25" PositionZUnit="µm" TheC="0" TheT="1" TheZ="1" />
+            <Plane DeltaT="1994.0" DeltaTUnit="ms" ExposureTime="1.0" ExposureTimeUnit="ms"
+                PositionX="256.0" PositionXUnit="µm" PositionY="-256.0" PositionYUnit="µm"
+                PositionZ="-2.25" PositionZUnit="µm" TheC="1" TheT="1" TheZ="1" />
+            <Plane DeltaT="2026.0" DeltaTUnit="ms" ExposureTime="1.0" ExposureTimeUnit="ms"
+                PositionX="256.0" PositionXUnit="µm" PositionY="-256.0" PositionYUnit="µm"
+                PositionZ="-2.25" PositionZUnit="µm" TheC="2" TheT="1" TheZ="1" />
+            <Plane DeltaT="2057.0" DeltaTUnit="ms" ExposureTime="1.0" ExposureTimeUnit="ms"
+                PositionX="256.0" PositionXUnit="µm" PositionY="-256.0" PositionYUnit="µm"
+                PositionZ="-0.5" PositionZUnit="µm" TheC="0" TheT="1" TheZ="2" />
+            <Plane DeltaT="2087.0" DeltaTUnit="ms" ExposureTime="1.0" ExposureTimeUnit="ms"
+                PositionX="256.0" PositionXUnit="µm" PositionY="-256.0" PositionYUnit="µm"
+                PositionZ="-0.5" PositionZUnit="µm" TheC="1" TheT="1" TheZ="2" />
+            <Plane DeltaT="2136.0" DeltaTUnit="ms" ExposureTime="1.0" ExposureTimeUnit="ms"
+                PositionX="256.0" PositionXUnit="µm" PositionY="-256.0" PositionYUnit="µm"
+                PositionZ="-0.5" PositionZUnit="µm" TheC="2" TheT="1" TheZ="2" />
+            <Plane DeltaT="2170.0" DeltaTUnit="ms" ExposureTime="1.0" ExposureTimeUnit="ms"
+                PositionX="256.0" PositionXUnit="µm" PositionY="-256.0" PositionYUnit="µm"
+                PositionZ="1.25" PositionZUnit="µm" TheC="0" TheT="1" TheZ="3" />
+            <Plane DeltaT="2206.0" DeltaTUnit="ms" ExposureTime="1.0" ExposureTimeUnit="ms"
+                PositionX="256.0" PositionXUnit="µm" PositionY="-256.0" PositionYUnit="µm"
+                PositionZ="1.25" PositionZUnit="µm" TheC="1" TheT="1" TheZ="3" />
+            <Plane DeltaT="2243.0" DeltaTUnit="ms" ExposureTime="1.0" ExposureTimeUnit="ms"
+                PositionX="256.0" PositionXUnit="µm" PositionY="-256.0" PositionYUnit="µm"
+                PositionZ="1.25" PositionZUnit="µm" TheC="2" TheT="1" TheZ="3" />
+            <Plane DeltaT="2276.0" DeltaTUnit="ms" ExposureTime="1.0" ExposureTimeUnit="ms"
+                PositionX="256.0" PositionXUnit="µm" PositionY="-256.0" PositionYUnit="µm"
+                PositionZ="3.0" PositionZUnit="µm" TheC="0" TheT="1" TheZ="4" />
+            <Plane DeltaT="2304.0" DeltaTUnit="ms" ExposureTime="1.0" ExposureTimeUnit="ms"
+                PositionX="256.0" PositionXUnit="µm" PositionY="-256.0" PositionYUnit="µm"
+                PositionZ="3.0" PositionZUnit="µm" TheC="1" TheT="1" TheZ="4" />
+            <Plane DeltaT="2332.0" DeltaTUnit="ms" ExposureTime="1.0" ExposureTimeUnit="ms"
+                PositionX="256.0" PositionXUnit="µm" PositionY="-256.0" PositionYUnit="µm"
+                PositionZ="3.0" PositionZUnit="µm" TheC="2" TheT="1" TheZ="4" />
+        </Pixels>
+    </Image>
+</OME> 

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -206,13 +206,13 @@ def test_update_unset(pixels: model.Pixels) -> None:
 
 
 @pytest.mark.filterwarnings("ignore::pytest.PytestUnraisableExceptionWarning")
-def test_transformations():
-    from ome_types import fixes
+def test_transformations() -> None:
+    from ome_types import etree_fixes
 
     # should not warn
     with warnings.catch_warnings():
         warnings.simplefilter("error")
-        from_xml(DATA / "MMStack.ome.xml", transformations=fixes.ALL_FIXES)
+        from_xml(DATA / "MMStack.ome.xml", transformations=etree_fixes.ALL_FIXES)
 
     # SHOULD warn
     with pytest.warns(match="Casting invalid DetectorID"):

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import datetime
 import io
+import warnings
 from pathlib import Path
 from typing import Any
 
@@ -260,3 +261,17 @@ def test_update_unset(pixels: model.Pixels) -> None:
     assert "CommentAnnotation" in xml
 
     assert from_xml(xml) == ome
+
+
+@pytest.mark.filterwarnings("ignore::pytest.PytestUnraisableExceptionWarning")
+def test_transformations():
+    from ome_types import fixes
+
+    # should not warn
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        from_xml(DATA / "MMStack.ome.xml", transformations=fixes.ALL_FIXES)
+
+    # SHOULD warn
+    with pytest.warns(match="Casting invalid DetectorID"):
+        from_xml(DATA / "MMStack.ome.xml")

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import datetime
 import io
+import sys
 import warnings
 from pathlib import Path
 from typing import Any
@@ -205,6 +206,7 @@ def test_update_unset(pixels: model.Pixels) -> None:
     assert from_xml(xml) == ome
 
 
+@pytest.mark.skipif(sys.version_info < (3, 8), reason="transform doesn't work on 3.7")
 @pytest.mark.filterwarnings("ignore::pytest.PytestUnraisableExceptionWarning")
 def test_transformations() -> None:
     from ome_types import etree_fixes

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -19,4 +19,4 @@ def test_transform() -> None:
     assert ome.instruments[0].microscope.manufacturer == "OME Insturuments"
 
     with pytest.warns(match="Transformed source"):
-        from_xml(DATA / "2008_instrument.ome.xml", warn_on_transform=True)
+        from_xml(DATA / "2008_instrument.ome.xml", warn_on_schema_update=True)


### PR DESCRIPTION
This PR addresses, and I'm going to say closes #129 

It adds a new `transformations` argument to `from_xml`
```py

AnyElementTree = xml.etree.ElementTree.ElementTree | lxml.etree._ElementTree
TransformationCallable = Callable[[AnyElementTree], AnyElementTree]

def from_xml(
    ...,
    transformations: Iterable[TransformationCallable] = (),
):

```

which lets the user add any number of "fixers" before converting xml.  There is a new module `ome_types.etree_fixes` with some standard fixes, and PRs can be opened to add more.  So, to use them all:

```py
from ome_types import etree_fixes, from_xml

from_xml("some_bad.ome.xml", transformations=etree_fixes.ALL_FIXES)
```

**HOWEVER:**
With v0.4.0, many of the fixes that are included in the aicsimageio `clean_ome_xml_for_known_issues` function referenced in #129 (i.e., ID and references fixes, namespace capitalization, ordering of elements) are no longer necessary as they are handled fine by default.  Some will emit warnings, and the `transformations` could be used to avoid those warnings.  But in general, I think this is a flexible enough approach that anyone can extend if needed