### PR TITLE
feat: catch and fix lowercase 'ome' in schemas

### DIFF
--- a/src/ome_types/_conversion.py
+++ b/src/ome_types/_conversion.py
@@ -455,7 +455,7 @@ def ensure_2016(
 
         return tree if as_tree else io.BytesIO(ET.tostring(tree, encoding="utf-8"))
 
-    raise ValueError(f"Unsupported document namespace {ns!r}")  # pragma: no cover
+    raise ValueError(f"Unsupported document namespace {ns_in!r}")
 
 
 def _normalize(source: XMLSource) -> FileLike:

--- a/src/ome_types/_conversion.py
+++ b/src/ome_types/_conversion.py
@@ -507,7 +507,7 @@ def _normalize(source: XMLSource) -> FileLike:
 
     if hasattr(source, "mode") and "b" not in source.mode:
         raise TypeError("File must be opened in binary mode")
-    raise TypeError(f"Unsupported source type {type(source)!r}")  # pragma: no cover
+    raise TypeError(f"Unsupported source type {type(source)!r}")
 
 
 def _apply_xslt(root: ElementOrTree, xslt_path: str | Path) -> _XSLTResultTree:

--- a/src/ome_types/_conversion.py
+++ b/src/ome_types/_conversion.py
@@ -38,7 +38,7 @@ if TYPE_CHECKING:
     from ome_types.model import OME
     from xsdata_pydantic_basemodel.bindings import XmlContext
 
-    XMLSource = Path | str | bytes | io.BytesIO
+    XMLSource = Path | str | bytes | BinaryIO
     FileLike = str | io.BufferedIOBase
     ElementOrTree = ET._Element | ET._ElementTree
 
@@ -503,9 +503,10 @@ def _normalize(source: XMLSource) -> FileLike:
     elif isinstance(source, bytes):
         return io.BytesIO(source)
     elif isinstance(source, io.BufferedIOBase):
-        if "b" not in source.mode:
-            raise ValueError("File must be opened in binary mode")
         return source
+
+    if hasattr(source, "mode") and "b" not in source.mode:
+        raise TypeError("File must be opened in binary mode")
     raise TypeError(f"Unsupported source type {type(source)!r}")  # pragma: no cover
 
 

--- a/tests/test_from_xml.py
+++ b/tests/test_from_xml.py
@@ -65,3 +65,8 @@ def test_uncapitalized_ns() -> None:
     xml = '<Detector xmlns="http://www.openmicroscopy.org/Schemas/ome/2013-06" />'
     ome = from_xml(xml)
     assert isinstance(ome, model.Detector)
+
+
+def test_weird_input():
+    with pytest.raises(ValueError, match="Could not parse XML"):
+        from_xml("ImageJmetadata")

--- a/tests/test_from_xml.py
+++ b/tests/test_from_xml.py
@@ -81,3 +81,6 @@ def test_must_be_binary(tmp_path: Path) -> None:
 
     with open(xml) as fh, pytest.raises(TypeError, match="must be opened in binary"):
         from_xml(fh)  # type: ignore[arg-type]
+
+    with pytest.raises(TypeError, match="Unsupported source type"):
+        from_xml(8)  # type: ignore[arg-type]

--- a/tests/test_from_xml.py
+++ b/tests/test_from_xml.py
@@ -67,6 +67,17 @@ def test_uncapitalized_ns() -> None:
     assert isinstance(ome, model.Detector)
 
 
-def test_weird_input():
+def test_weird_input() -> None:
     with pytest.raises(ValueError, match="Could not parse XML"):
         from_xml("ImageJmetadata")
+
+
+def test_must_be_binary(tmp_path: Path) -> None:
+    xml = tmp_path / "test.xml"
+    xml.write_text('<OME xmlns="http://www.openmicroscopy.org/Schemas/ome/2013-06" />')
+
+    with open(xml, "rb") as fh:
+        assert isinstance(from_xml(fh), model.OME)
+
+    with open(xml) as fh, pytest.raises(TypeError, match="must be opened in binary"):
+        from_xml(fh)  # type: ignore[arg-type]

--- a/tests/test_from_xml.py
+++ b/tests/test_from_xml.py
@@ -56,6 +56,12 @@ def test_get_root_ome_type() -> None:
     assert isinstance(obj, model.XMLAnnotation)
 
 
-def test_unknown_ns():
+def test_unknown_ns() -> None:
     with pytest.raises(ValueError, match="Unsupported document namespace"):
         from_xml('<Image xmlns="http://unknown.org" />')
+
+
+def test_uncapitalized_ns() -> None:
+    xml = '<Detector xmlns="http://www.openmicroscopy.org/Schemas/ome/2013-06" />'
+    ome = from_xml(xml)
+    assert isinstance(ome, model.Detector)

--- a/tests/test_from_xml.py
+++ b/tests/test_from_xml.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+import io
+from pathlib import Path
+
+import pytest
+from pydantic import ValidationError
+
+from ome_types import from_xml, model
+from ome_types._conversion import OME_2016_06_URI, _get_root_ome_type
+
+DATA = Path(__file__).parent / "data"
+VALIDATE = [False]
+
+
+@pytest.mark.parametrize("validate", VALIDATE)
+def test_from_valid_xml(valid_xml: Path, validate: bool) -> None:
+    ome = model.OME.from_xml(valid_xml, validate=validate)  # class method for coverage
+    assert ome
+    assert repr(ome)
+
+
+@pytest.mark.parametrize("validate", VALIDATE)
+def test_from_invalid_xml(invalid_xml: Path, validate: bool) -> None:
+    if validate:
+        with pytest.raises(ValidationError):
+            from_xml(invalid_xml, validate=validate)
+    else:
+        with pytest.warns():
+            from_xml(invalid_xml, validate=validate)
+
+
+def test_with_ome_ns() -> None:
+    assert from_xml(DATA / "ome_ns.ome.xml").experimenters
+
+
+def test_get_root_ome_type() -> None:
+    xml = io.BytesIO(f'<Image xmlns="{OME_2016_06_URI}" />'.encode())
+    t = _get_root_ome_type(xml)
+    assert t is model.Image
+
+    xml = io.BytesIO(f'<ome:Image xmlns:ome="{OME_2016_06_URI}" />'.encode())
+    t = _get_root_ome_type(xml)
+    assert t is model.Image
+
+    with pytest.raises(ValueError, match="Unknown root element"):
+        _get_root_ome_type(io.BytesIO(b"<Imdgage />"))
+
+    # this can be used to instantiate XML with a non OME root type:
+    obj = from_xml(f'<Project xmlns="{OME_2016_06_URI}" />')
+    assert isinstance(obj, model.Project)
+    obj = from_xml(
+        f'<XMLAnnotation xmlns="{OME_2016_06_URI}"><Value><Data>'
+        "</Data></Value></XMLAnnotation>"
+    )
+    assert isinstance(obj, model.XMLAnnotation)
+
+
+def test_unknown_ns():
+    with pytest.raises(ValueError, match="Unsupported document namespace"):
+        from_xml('<Image xmlns="http://unknown.org" />')

--- a/tests/test_from_xml.py
+++ b/tests/test_from_xml.py
@@ -62,7 +62,7 @@ def test_unknown_ns() -> None:
 
 
 def test_uncapitalized_ns() -> None:
-    xml = '<Detector xmlns="http://www.openmicroscopy.org/Schemas/ome/2013-06" />'
+    xml = '<Detector xmlns="http://www.openmicroscopy.org/Schemas/ome/2016-06" />'
     ome = from_xml(xml)
     assert isinstance(ome, model.Detector)
 
@@ -74,7 +74,7 @@ def test_weird_input() -> None:
 
 def test_must_be_binary(tmp_path: Path) -> None:
     xml = tmp_path / "test.xml"
-    xml.write_text('<OME xmlns="http://www.openmicroscopy.org/Schemas/ome/2013-06" />')
+    xml.write_text('<OME xmlns="http://www.openmicroscopy.org/Schemas/ome/2016-06" />')
 
     with open(xml, "rb") as fh:
         assert isinstance(from_xml(fh), model.OME)

--- a/tests/test_ids.py
+++ b/tests/test_ids.py
@@ -1,18 +1,22 @@
 import pytest
 
 from ome_types import from_xml
+from ome_types._mixins import _ids
 from ome_types.model import Line, Rectangle
 
 
-def test_shape_ids() -> None:
+def test_shape_ids(monkeypatch: "pytest.MonkeyPatch") -> None:
+    monkeypatch.setattr(_ids, "ID_COUNTER", {})
     rect = Rectangle(x=0, y=0, width=1, height=1)
     line = Line(x1=0, y1=0, x2=1, y2=1)
     assert rect.id == "Shape:0"
     assert line.id == "Shape:1"
 
 
-def test_id_conversion() -> None:
+def test_id_conversion(monkeypatch: "pytest.MonkeyPatch") -> None:
     """When converting ids, we should still be preserving references."""
+    monkeypatch.setattr(_ids, "ID_COUNTER", {})
+
     XML_WITH_BAD_REFS = """<?xml version="1.0" ?>
     <OME xmlns="http://www.openmicroscopy.org/Schemas/OME/2016-06">
         <Instrument ID="Microscope">

--- a/tests/test_ids.py
+++ b/tests/test_ids.py
@@ -1,8 +1,20 @@
 import pytest
 
-from ome_types import from_xml
+from ome_types import from_xml, model
 from ome_types._mixins import _ids
 from ome_types.model import Line, Rectangle
+
+
+def test_no_id() -> None:
+    """Test that ids are optional, and auto-increment."""
+    i = model.Instrument(id=20)  # type: ignore
+    assert i.id == "Instrument:20"
+    i2 = model.Instrument()  # type: ignore
+    assert i2.id == "Instrument:21"
+
+    # but validation still works
+    with pytest.warns(match="Casting invalid InstrumentID"):
+        model.Instrument(id="nonsense")
 
 
 def test_shape_ids(monkeypatch: "pytest.MonkeyPatch") -> None:

--- a/tests/test_ids.py
+++ b/tests/test_ids.py
@@ -5,8 +5,10 @@ from ome_types._mixins import _ids
 from ome_types.model import Line, Rectangle
 
 
-def test_no_id() -> None:
+def test_no_id(monkeypatch: "pytest.MonkeyPatch") -> None:
     """Test that ids are optional, and auto-increment."""
+    monkeypatch.setattr(_ids, "ID_COUNTER", {})
+
     i = model.Instrument(id=20)  # type: ignore
     assert i.id == "Instrument:20"
     i2 = model.Instrument()  # type: ignore

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -9,34 +9,14 @@ import pytest
 from pydantic import ValidationError
 
 from ome_types import from_tiff, from_xml, model, to_xml
-from ome_types._conversion import OME_2016_06_URI, _get_root_ome_type
 
 DATA = Path(__file__).parent / "data"
-VALIDATE = [False]
 
 
-@pytest.mark.parametrize("validate", VALIDATE)
-def test_from_valid_xml(valid_xml: Path, validate: bool) -> None:
-    ome = model.OME.from_xml(valid_xml, validate=validate)  # class method for coverage
-    assert ome
-    assert repr(ome)
-
-
-@pytest.mark.parametrize("validate", VALIDATE)
-def test_from_invalid_xml(invalid_xml: Path, validate: bool) -> None:
-    if validate:
-        with pytest.raises(ValidationError):
-            from_xml(invalid_xml, validate=validate)
-    else:
-        with pytest.warns():
-            from_xml(invalid_xml, validate=validate)
-
-
-@pytest.mark.parametrize("validate", VALIDATE)
-def test_from_tiff(validate: bool) -> None:
+def test_from_tiff() -> None:
     """Test that OME metadata extractions from Tiff headers works."""
     _path = DATA / "ome.tiff"
-    ome = from_tiff(_path, validate=validate)
+    ome = from_tiff(_path)
     assert len(ome.images) == 1
     assert ome.images[0].id == "Image:0"
     assert ome.images[0].pixels.size_x == 6
@@ -71,32 +51,6 @@ def test_refs() -> None:
     xml = DATA / "two-screens-two-plates-four-wells.ome.xml"
     ome = from_xml(xml)
     assert ome.screens[0].plate_refs[0].ref is ome.plates[0]
-
-
-def test_with_ome_ns() -> None:
-    assert from_xml(DATA / "ome_ns.ome.xml").experimenters
-
-
-def test_get_root_ome_type() -> None:
-    xml = io.BytesIO(f'<Image xmlns="{OME_2016_06_URI}" />'.encode())
-    t = _get_root_ome_type(xml)
-    assert t is model.Image
-
-    xml = io.BytesIO(f'<ome:Image xmlns:ome="{OME_2016_06_URI}" />'.encode())
-    t = _get_root_ome_type(xml)
-    assert t is model.Image
-
-    with pytest.raises(ValueError, match="Unknown root element"):
-        _get_root_ome_type(io.BytesIO(b"<Imdgage />"))
-
-    # this can be used to instantiate XML with a non OME root type:
-    obj = from_xml(f'<Project xmlns="{OME_2016_06_URI}" />')
-    assert isinstance(obj, model.Project)
-    obj = from_xml(
-        f'<XMLAnnotation xmlns="{OME_2016_06_URI}"><Value><Data>'
-        "</Data></Value></XMLAnnotation>"
-    )
-    assert isinstance(obj, model.XMLAnnotation)
 
 
 def test_datetimes() -> None:

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -26,18 +26,6 @@ def test_from_tiff() -> None:
         assert model.OME.from_tiff(fh) == ome  # class method for coverage
 
 
-def test_no_id() -> None:
-    """Test that ids are optional, and auto-increment."""
-    i = model.Instrument(id=20)  # type: ignore
-    assert i.id == "Instrument:20"
-    i2 = model.Instrument()  # type: ignore
-    assert i2.id == "Instrument:21"
-
-    # but validation still works
-    with pytest.warns(match="Casting invalid InstrumentID"):
-        model.Instrument(id="nonsense")
-
-
 def test_required_missing() -> None:
     """Test subclasses with non-default arguments still work."""
     with pytest.raises(ValidationError, match="required"):


### PR DESCRIPTION
aicsimageio has a few examples of xml with a lowercase "ome" in the schema name.  this fixes that